### PR TITLE
UPSTREAM: 3606: feat: Migrate to autoscalingv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 
 ### Breaking Changes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issue/XXX))
+- **General:** Change API version of HPA from `autoscaling/v2beta2` to `autoscaling/v2` ([#2462](https://github.com/kedacore/keda/issues/2462))
 
 ### Other
 

--- a/CREATE-NEW-SCALER.md
+++ b/CREATE-NEW-SCALER.md
@@ -52,15 +52,15 @@ For example:
 
 >**Note:** There is a naming helper function `GenerateMetricNameWithIndex(scalerIndex int, metricName string)`, that receives the current index and the original metric name (without the prefix) and returns the concatenated string using the convention (please use this function).<br>Next lines are an example about how to use it:
 >```golang
->func (s *artemisScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
->	externalMetric := &v2beta2.ExternalMetricSource{
->		Metric: v2beta2.MetricIdentifier{
+>func (s *artemisScaler) GetMetricSpecForScaling() []v2.MetricSpec {
+>	externalMetric := &v2.ExternalMetricSource{
+>		Metric: v2.MetricIdentifier{
 >			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "artemis", s.metadata.brokerName, s.metadata.queueName))),
 >		},
 >		Target: GetMetricTarget(s.metricType, s.metadata.queueLength),
 >	}
->	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: artemisMetricType}
->	return []v2beta2.MetricSpec{metricSpec}
+>	metricSpec := v2.MetricSpec{External: externalMetric, Type: artemisMetricType}
+>	return []v2.MetricSpec{metricSpec}
 >}
 >```
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ GO_LDFLAGS="-X=github.com/kedacore/keda/v2/version.GitCommit=$(GIT_COMMIT) -X=gi
 COSIGN_FLAGS ?= -a GIT_HASH=${GIT_COMMIT} -a GIT_VERSION=${VERSION} -a BUILD_DATE=${DATE}
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.22
+ENVTEST_K8S_VERSION = 1.23
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.

--- a/apis/keda/v1alpha1/scaledobject_types.go
+++ b/apis/keda/v1alpha1/scaledobject_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -103,7 +103,7 @@ type AdvancedConfig struct {
 // HorizontalPodAutoscalerConfig specifies horizontal scale config
 type HorizontalPodAutoscalerConfig struct {
 	// +optional
-	Behavior *autoscalingv2beta2.HorizontalPodAutoscalerBehavior `json:"behavior,omitempty"`
+	Behavior *autoscalingv2.HorizontalPodAutoscalerBehavior `json:"behavior,omitempty"`
 	// +optional
 	Name string `json:"name,omitempty"`
 }
@@ -128,7 +128,7 @@ type ScaleTriggers struct {
 	// +optional
 	AuthenticationRef *ScaledObjectAuthRef `json:"authenticationRef,omitempty"`
 	// +optional
-	MetricType autoscalingv2beta2.MetricTargetType `json:"metricType,omitempty"`
+	MetricType autoscalingv2.MetricTargetType `json:"metricType,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/apis/keda/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/keda/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/autoscaling/v2beta2"
+	"k8s.io/api/autoscaling/v2"
 	"k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -375,7 +375,7 @@ func (in *HorizontalPodAutoscalerConfig) DeepCopyInto(out *HorizontalPodAutoscal
 	*out = *in
 	if in.Behavior != nil {
 		in, out := &in.Behavior, &out.Behavior
-		*out = new(v2beta2.HorizontalPodAutoscalerBehavior)
+		*out = new(v2.HorizontalPodAutoscalerBehavior)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/controllers/keda/hpa_test.go
+++ b/controllers/keda/hpa_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -140,14 +140,14 @@ func setupTest(health map[string]v1alpha1.HealthStatus, scaler *mock_scalers.Moc
 		Logger:   logr.Discard(),
 		Recorder: nil,
 	}
-	metricSpec := v2beta2.MetricSpec{
-		External: &v2beta2.ExternalMetricSource{
-			Metric: v2beta2.MetricIdentifier{
+	metricSpec := v2.MetricSpec{
+		External: &v2.ExternalMetricSource{
+			Metric: v2.MetricIdentifier{
 				Name: "some metric name",
 			},
 		},
 	}
-	metricSpecs := []v2beta2.MetricSpec{metricSpec}
+	metricSpecs := []v2.MetricSpec{metricSpec}
 	ctx := context.Background()
 	scaler.EXPECT().GetMetricSpecForScaling(ctx).Return(metricSpecs)
 	scaleHandler.EXPECT().GetScalersCache(context.Background(), gomock.Eq(scaledObject)).Return(&scalersCache, nil)

--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -269,7 +269,7 @@ var _ = Describe("ScaledObjectController", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Get and confirm the HPA.
-			hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "keda-hpa-clean-up-test", Namespace: "default"}, hpa)
 			}).ShouldNot(HaveOccurred())
@@ -329,7 +329,7 @@ var _ = Describe("ScaledObjectController", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Get and confirm the HPA.
-			hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: fmt.Sprintf("keda-hpa-%s", soName), Namespace: "default"}, hpa)
 			}).ShouldNot(HaveOccurred())
@@ -384,7 +384,7 @@ var _ = Describe("ScaledObjectController", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Get and confirm the HPA.
-			hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "keda-hpa-cache-regenerate", Namespace: "default"}, hpa)
 			}).ShouldNot(HaveOccurred())
@@ -421,7 +421,7 @@ var _ = Describe("ScaledObjectController", func() {
 			time.Sleep(30 * time.Second)
 
 			// Get and confirm the HPA.
-			hpa2 := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+			hpa2 := &autoscalingv2.HorizontalPodAutoscaler{}
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "keda-hpa-cache-regenerate", Namespace: "default"}, hpa2)
 			}).ShouldNot(HaveOccurred())
@@ -469,7 +469,7 @@ var _ = Describe("ScaledObjectController", func() {
 			Ω(err).ToNot(HaveOccurred())
 
 			// Get and confirm the HPA
-			hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "keda-hpa-" + soName, Namespace: "default"}, hpa)
 			}).ShouldNot(HaveOccurred())
@@ -523,7 +523,7 @@ var _ = Describe("ScaledObjectController", func() {
 			Ω(err).ToNot(HaveOccurred())
 
 			// Get and confirm the HPA
-			hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "keda-hpa-" + soName, Namespace: "default"}, hpa)
 			}).ShouldNot(HaveOccurred())
@@ -686,14 +686,14 @@ var _ = Describe("ScaledObjectController", func() {
 				Triggers: []kedav1alpha1.ScaleTriggers{
 					{
 						Type:       "cpu",
-						MetricType: autoscalingv2beta2.UtilizationMetricType,
+						MetricType: autoscalingv2.UtilizationMetricType,
 						Metadata: map[string]string{
 							"value": "50",
 						},
 					},
 					{
 						Type:       "external-mock",
-						MetricType: autoscalingv2beta2.AverageValueMetricType,
+						MetricType: autoscalingv2.AverageValueMetricType,
 						Metadata:   map[string]string{},
 					},
 				},
@@ -710,7 +710,7 @@ var _ = Describe("ScaledObjectController", func() {
 		}, 5*time.Second).Should(Equal(metav1.ConditionTrue))
 
 		// check hpa
-		hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 		Eventually(func() int {
 			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: getHPAName(so), Namespace: "default"}, hpa)
 			Expect(err).ToNot(HaveOccurred())
@@ -730,12 +730,12 @@ var _ = Describe("ScaledObjectController", func() {
 		// mock kube-controller-manager request v1beta1.custom.metrics.k8s.io api GetMetrics
 		err = k8sClient.Get(context.Background(), types.NamespacedName{Name: getHPAName(so), Namespace: "default"}, hpa)
 		Expect(err).ToNot(HaveOccurred())
-		hpa.Status.CurrentMetrics = []autoscalingv2beta2.MetricStatus{
+		hpa.Status.CurrentMetrics = []autoscalingv2.MetricStatus{
 			{
-				Type: autoscalingv2beta2.ResourceMetricSourceType,
-				Resource: &autoscalingv2beta2.ResourceMetricStatus{
+				Type: autoscalingv2.ResourceMetricSourceType,
+				Resource: &autoscalingv2.ResourceMetricStatus{
 					Name: corev1.ResourceCPU,
-					Current: autoscalingv2beta2.MetricValueStatus{
+					Current: autoscalingv2.MetricValueStatus{
 						Value: resource.NewQuantity(int64(100), resource.DecimalSI),
 					},
 				},
@@ -746,7 +746,7 @@ var _ = Describe("ScaledObjectController", func() {
 
 		// hpa metrics will only left CPU metric
 		Eventually(func() int {
-			hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: getHPAName(so), Namespace: "default"}, hpa)
 			Expect(err).ToNot(HaveOccurred())
 			return len(hpa.Spec.Metrics)
@@ -764,7 +764,7 @@ var _ = Describe("ScaledObjectController", func() {
 
 		// hpa will recover
 		Eventually(func() int {
-			hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: getHPAName(so), Namespace: "default"}, hpa)
 			Expect(err).ToNot(HaveOccurred())
 			return len(hpa.Spec.Metrics)

--- a/pkg/mock/mock_scaler/mock_scaler.go
+++ b/pkg/mock/mock_scaler/mock_scaler.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	labels "k8s.io/apimachinery/pkg/labels"
 	external_metrics "k8s.io/metrics/pkg/apis/external_metrics"
 )
@@ -52,10 +52,10 @@ func (mr *MockScalerMockRecorder) Close(ctx interface{}) *gomock.Call {
 }
 
 // GetMetricSpecForScaling mocks base method.
-func (m *MockScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
+func (m *MockScaler) GetMetricSpecForScaling(ctx context.Context) []v2.MetricSpec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricSpecForScaling", ctx)
-	ret0, _ := ret[0].([]v2beta2.MetricSpec)
+	ret0, _ := ret[0].([]v2.MetricSpec)
 	return ret0
 }
 
@@ -133,10 +133,10 @@ func (mr *MockPushScalerMockRecorder) Close(ctx interface{}) *gomock.Call {
 }
 
 // GetMetricSpecForScaling mocks base method.
-func (m *MockPushScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
+func (m *MockPushScaler) GetMetricSpecForScaling(ctx context.Context) []v2.MetricSpec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricSpecForScaling", ctx)
-	ret0, _ := ret[0].([]v2beta2.MetricSpec)
+	ret0, _ := ret[0].([]v2.MetricSpec)
 	return ret0
 }
 

--- a/pkg/provider/fallback_test.go
+++ b/pkg/provider/fallback_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -208,10 +208,10 @@ var _ = Describe("fallback", func() {
 		)
 
 		qty := resource.NewQuantity(int64(3), resource.DecimalSI)
-		metricsSpec := v2beta2.MetricSpec{
-			External: &v2beta2.ExternalMetricSource{
-				Target: v2beta2.MetricTarget{
-					Type:  v2beta2.UtilizationMetricType,
+		metricsSpec := v2.MetricSpec{
+			External: &v2.ExternalMetricSource{
+				Target: v2.MetricTarget{
+					Type:  v2.UtilizationMetricType,
 					Value: qty,
 				},
 			},
@@ -436,12 +436,12 @@ func primeGetMetrics(scaler *mock_scalers.MockScaler, value int64) {
 	scaler.EXPECT().GetMetrics(gomock.Any(), gomock.Eq(metricName), gomock.Any()).Return([]external_metrics.ExternalMetricValue{expectedMetric}, nil)
 }
 
-func createMetricSpec(averageValue int) v2beta2.MetricSpec {
+func createMetricSpec(averageValue int) v2.MetricSpec {
 	qty := resource.NewQuantity(int64(averageValue), resource.DecimalSI)
-	return v2beta2.MetricSpec{
-		External: &v2beta2.ExternalMetricSource{
-			Target: v2beta2.MetricTarget{
-				Type:         v2beta2.AverageValueMetricType,
+	return v2.MetricSpec{
+		External: &v2.ExternalMetricSource{
+			Target: v2.MetricTarget{
+				Type:         v2.AverageValueMetricType,
 				AverageValue: qty,
 			},
 		},

--- a/pkg/scalers/activemq_scaler.go
+++ b/pkg/scalers/activemq_scaler.go
@@ -13,7 +13,7 @@ import (
 	"text/template"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -21,7 +21,7 @@ import (
 )
 
 type activeMQScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *activeMQMetadata
 	httpClient *http.Client
 	logger     logr.Logger
@@ -266,17 +266,17 @@ func (s *activeMQScaler) getQueueMessageCount(ctx context.Context) (int64, error
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *activeMQScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *activeMQScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: s.metadata.metricName,
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetQueueSize),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *activeMQScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {

--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -19,7 +19,7 @@ import (
 )
 
 type artemisScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *artemisMetadata
 	httpClient *http.Client
 	logger     logr.Logger
@@ -267,15 +267,15 @@ func (s *artemisScaler) getQueueMessageCount(ctx context.Context) (int64, error)
 	return messageCount, nil
 }
 
-func (s *artemisScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *artemisScaler) GetMetricSpecForScaling(ctx context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("artemis-%s", s.metadata.queueName))),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.queueLength),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: artemisMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: artemisMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/go-logr/logr"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -29,7 +29,7 @@ const (
 )
 
 type awsCloudwatchScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *awsCloudwatchMetadata
 	cwClient   cloudwatchiface.CloudWatchAPI
 	logger     logr.Logger
@@ -303,7 +303,7 @@ func (s *awsCloudwatchScaler) GetMetrics(ctx context.Context, metricName string,
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (s *awsCloudwatchScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *awsCloudwatchScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	var metricNameSuffix string
 
 	if s.metadata.expression != "" {
@@ -312,14 +312,14 @@ func (s *awsCloudwatchScaler) GetMetricSpecForScaling(context.Context) []v2beta2
 		metricNameSuffix = s.metadata.dimensionName[0]
 	}
 
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("aws-cloudwatch-%s", metricNameSuffix))),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.targetMetricValue),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *awsCloudwatchScaler) IsActive(ctx context.Context) (bool, error) {

--- a/pkg/scalers/aws_dynamodb_scaler.go
+++ b/pkg/scalers/aws_dynamodb_scaler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/go-logr/logr"
 	"go.mongodb.org/mongo-driver/bson"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -23,7 +23,7 @@ import (
 )
 
 type awsDynamoDBScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *awsDynamoDBMetadata
 	dbClient   dynamodbiface.DynamoDBAPI
 	logger     logr.Logger
@@ -183,16 +183,16 @@ func (s *awsDynamoDBScaler) GetMetrics(ctx context.Context, metricName string, m
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (s *awsDynamoDBScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *awsDynamoDBScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: s.metadata.metricName,
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetValue),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
 
-	return []v2beta2.MetricSpec{
+	return []v2.MetricSpec{
 		metricSpec,
 	}
 }

--- a/pkg/scalers/aws_dynamodb_streams_scaler.go
+++ b/pkg/scalers/aws_dynamodb_streams_scaler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams/dynamodbstreamsiface"
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,7 +29,7 @@ const (
 )
 
 type awsDynamoDBStreamsScaler struct {
-	metricType     v2beta2.MetricTargetType
+	metricType     v2.MetricTargetType
 	metadata       *awsDynamoDBStreamsMetadata
 	streamArn      *string
 	dbStreamClient dynamodbstreamsiface.DynamoDBStreamsAPI
@@ -179,15 +179,15 @@ func (s *awsDynamoDBStreamsScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *awsDynamoDBStreamsScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *awsDynamoDBStreamsScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("aws-dynamodb-streams-%s", s.metadata.tableName))),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetShardCount),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -25,7 +25,7 @@ const (
 )
 
 type awsKinesisStreamScaler struct {
-	metricType    v2beta2.MetricTargetType
+	metricType    v2.MetricTargetType
 	metadata      *awsKinesisStreamMetadata
 	kinesisClient kinesisiface.KinesisAPI
 	logger        logr.Logger
@@ -150,15 +150,15 @@ func (s *awsKinesisStreamScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *awsKinesisStreamScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *awsKinesisStreamScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("aws-kinesis-%s", s.metadata.streamName))),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetShardCount),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -33,7 +33,7 @@ var awsSqsQueueMetricNames = []string{
 }
 
 type awsSqsQueueScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *awsSqsQueueMetadata
 	sqsClient  sqsiface.SQSAPI
 	logger     logr.Logger
@@ -191,15 +191,15 @@ func (s *awsSqsQueueScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *awsSqsQueueScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *awsSqsQueueScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("aws-sqs-%s", s.metadata.queueName))),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetQueueLength),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/azure_app_insights_scaler.go
+++ b/pkg/scalers/azure_app_insights_scaler.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -35,7 +35,7 @@ type azureAppInsightsMetadata struct {
 }
 
 type azureAppInsightsScaler struct {
-	metricType  v2beta2.MetricTargetType
+	metricType  v2.MetricTargetType
 	metadata    *azureAppInsightsMetadata
 	podIdentity kedav1alpha1.AuthPodIdentity
 	logger      logr.Logger
@@ -179,15 +179,15 @@ func (s *azureAppInsightsScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *azureAppInsightsScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *azureAppInsightsScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-app-insights-%s", s.metadata.azureAppInsightsInfo.MetricID))),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.targetValue),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/azure_blob_scaler.go
+++ b/pkg/scalers/azure_blob_scaler.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/gobwas/glob"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -42,7 +42,7 @@ const (
 )
 
 type azureBlobScaler struct {
-	metricType  v2beta2.MetricTargetType
+	metricType  v2.MetricTargetType
 	metadata    *azure.BlobMetadata
 	podIdentity kedav1alpha1.AuthPodIdentity
 	httpClient  *http.Client
@@ -201,15 +201,15 @@ func (s *azureBlobScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *azureBlobScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *azureBlobScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.ScalerIndex, s.metadata.MetricName),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.TargetBlobCount),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/azure_data_explorer_scaler.go
+++ b/pkg/scalers/azure_data_explorer_scaler.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/go-logr/logr"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -33,7 +33,7 @@ import (
 )
 
 type azureDataExplorerScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *azure.DataExplorerMetadata
 	client     *kusto.Client
 	name       string
@@ -180,15 +180,15 @@ func (s azureDataExplorerScaler) GetMetrics(ctx context.Context, metricName stri
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (s azureDataExplorerScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s azureDataExplorerScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: s.metadata.MetricName,
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.Threshold),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s azureDataExplorerScaler) IsActive(ctx context.Context) (bool, error) {

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -29,7 +29,7 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	az "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/go-logr/logr"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -49,7 +49,7 @@ const (
 )
 
 type azureEventHubScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *eventHubMetadata
 	client     *eventhub.Hub
 	httpClient *http.Client
@@ -299,15 +299,15 @@ func (s *azureEventHubScaler) IsActive(ctx context.Context) (bool, error) {
 }
 
 // GetMetricSpecForScaling returns metric spec
-func (s *azureEventHubScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *azureEventHubScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-eventhub-%s", s.metadata.eventHubInfo.EventHubConsumerGroup))),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.threshold),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: eventHubMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: eventHubMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns metric using total number of unprocessed events in event hub

--- a/pkg/scalers/azure_log_analytics_scaler.go
+++ b/pkg/scalers/azure_log_analytics_scaler.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/Azure/azure-amqp-common-go/v3/auth"
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -49,7 +49,7 @@ const (
 )
 
 type azureLogAnalyticsScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *azureLogAnalyticsMetadata
 	cache      *sessionCache
 	name       string
@@ -264,7 +264,7 @@ func (s *azureLogAnalyticsScaler) IsActive(ctx context.Context) (bool, error) {
 	return s.cache.metricValue > s.metadata.activationThreshold, nil
 }
 
-func (s *azureLogAnalyticsScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
+func (s *azureLogAnalyticsScaler) GetMetricSpecForScaling(ctx context.Context) []v2.MetricSpec {
 	err := s.updateCache(ctx)
 
 	if err != nil {
@@ -272,14 +272,14 @@ func (s *azureLogAnalyticsScaler) GetMetricSpecForScaling(ctx context.Context) [
 		return nil
 	}
 
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, s.metadata.metricName),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.cache.metricThreshold),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -24,7 +24,7 @@ import (
 
 	az "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -40,7 +40,7 @@ const (
 )
 
 type azureMonitorScaler struct {
-	metricType  v2beta2.MetricTargetType
+	metricType  v2.MetricTargetType
 	metadata    *azureMonitorMetadata
 	podIdentity kedav1alpha1.AuthPodIdentity
 	logger      logr.Logger
@@ -229,15 +229,15 @@ func (s *azureMonitorScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *azureMonitorScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *azureMonitorScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-monitor-%s", s.metadata.azureMonitorInfo.Name))),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.targetValue),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -32,7 +32,7 @@ type azurePipelinesPoolIDResponse struct {
 }
 
 type azurePipelinesScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *azurePipelinesMetadata
 	httpClient *http.Client
 	logger     logr.Logger
@@ -317,15 +317,15 @@ func getCanAgentParentFulfilJob(v map[string]interface{}, metadata *azurePipelin
 	return false
 }
 
-func (s *azurePipelinesScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *azurePipelinesScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-pipelines-%d", s.metadata.poolID))),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetPipelinesQueueLength),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *azurePipelinesScaler) IsActive(ctx context.Context) (bool, error) {

--- a/pkg/scalers/azure_queue_scaler.go
+++ b/pkg/scalers/azure_queue_scaler.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -40,7 +40,7 @@ const (
 )
 
 type azureQueueScaler struct {
-	metricType  v2beta2.MetricTargetType
+	metricType  v2.MetricTargetType
 	metadata    *azureQueueMetadata
 	podIdentity kedav1alpha1.AuthPodIdentity
 	httpClient  *http.Client
@@ -183,15 +183,15 @@ func (s *azureQueueScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *azureQueueScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *azureQueueScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-queue-%s", s.metadata.queueName))),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetQueueLength),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -26,7 +26,7 @@ import (
 	servicebus "github.com/Azure/azure-service-bus-go"
 	az "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -50,7 +50,7 @@ const (
 
 type azureServiceBusScaler struct {
 	ctx         context.Context
-	metricType  v2beta2.MetricTargetType
+	metricType  v2.MetricTargetType
 	metadata    *azureServiceBusMetadata
 	podIdentity kedav1alpha1.AuthPodIdentity
 	httpClient  *http.Client
@@ -201,7 +201,7 @@ func (s *azureServiceBusScaler) Close(context.Context) error {
 }
 
 // Returns the metric spec to be used by the HPA
-func (s *azureServiceBusScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *azureServiceBusScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	metricName := ""
 	if s.metadata.entityType == queue {
 		metricName = s.metadata.queueName
@@ -209,14 +209,14 @@ func (s *azureServiceBusScaler) GetMetricSpecForScaling(context.Context) []v2bet
 		metricName = s.metadata.topicName
 	}
 
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-servicebus-%s", metricName))),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetLength),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // Returns the current metrics to be served to the HPA

--- a/pkg/scalers/cassandra_scaler.go
+++ b/pkg/scalers/cassandra_scaler.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/gocql/gocql"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -17,7 +17,7 @@ import (
 
 // cassandraScaler exposes a data pointer to CassandraMetadata and gocql.Session connection.
 type cassandraScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *CassandraMetadata
 	session    *gocql.Session
 	logger     logr.Logger
@@ -191,18 +191,18 @@ func (s *cassandraScaler) IsActive(ctx context.Context) (bool, error) {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler.
-func (s *cassandraScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *cassandraScaler) GetMetricSpecForScaling(ctx context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, s.metadata.metricName),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetQueryValue),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
 
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns a value for a supported metric or an error if there is a problem getting the metric.

--- a/pkg/scalers/cpu_memory_scaler_test.go
+++ b/pkg/scalers/cpu_memory_scaler_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 )
 
 type parseCPUMemoryMetadataTestData struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   map[string]string
 	isError    bool
 }
@@ -32,11 +32,11 @@ var testCPUMemoryMetadata = []parseCPUMemoryMetadataTestData{
 	{"", validCPUMemoryMetadata, false},
 	{"", validContainerCPUMemoryMetadata, false},
 	{"", map[string]string{"type": "Utilization", "value": "50"}, false},
-	{v2beta2.UtilizationMetricType, map[string]string{"value": "50"}, false},
+	{v2.UtilizationMetricType, map[string]string{"value": "50"}, false},
 	{"", map[string]string{"type": "AverageValue", "value": "50"}, false},
-	{v2beta2.AverageValueMetricType, map[string]string{"value": "50"}, false},
+	{v2.AverageValueMetricType, map[string]string{"value": "50"}, false},
 	{"", map[string]string{"type": "Value", "value": "50"}, true},
-	{v2beta2.ValueMetricType, map[string]string{"value": "50"}, true},
+	{v2.ValueMetricType, map[string]string{"value": "50"}, true},
 	{"", map[string]string{"type": "AverageValue"}, true},
 	{"", map[string]string{"type": "xxx", "value": "50"}, true},
 }
@@ -65,21 +65,21 @@ func TestGetMetricSpecForScaling(t *testing.T) {
 	scaler, _ := NewCPUMemoryScaler(v1.ResourceCPU, config)
 	metricSpec := scaler.GetMetricSpecForScaling(context.Background())
 
-	assert.Equal(t, metricSpec[0].Type, v2beta2.ResourceMetricSourceType)
+	assert.Equal(t, metricSpec[0].Type, v2.ResourceMetricSourceType)
 	assert.Equal(t, metricSpec[0].Resource.Name, v1.ResourceCPU)
-	assert.Equal(t, metricSpec[0].Resource.Target.Type, v2beta2.UtilizationMetricType)
+	assert.Equal(t, metricSpec[0].Resource.Target.Type, v2.UtilizationMetricType)
 
 	// Using trigger.metricType field for type
 	config = &ScalerConfig{
 		TriggerMetadata: map[string]string{"value": "50"},
-		MetricType:      v2beta2.UtilizationMetricType,
+		MetricType:      v2.UtilizationMetricType,
 	}
 	scaler, _ = NewCPUMemoryScaler(v1.ResourceCPU, config)
 	metricSpec = scaler.GetMetricSpecForScaling(context.Background())
 
-	assert.Equal(t, metricSpec[0].Type, v2beta2.ResourceMetricSourceType)
+	assert.Equal(t, metricSpec[0].Type, v2.ResourceMetricSourceType)
 	assert.Equal(t, metricSpec[0].Resource.Name, v1.ResourceCPU)
-	assert.Equal(t, metricSpec[0].Resource.Target.Type, v2beta2.UtilizationMetricType)
+	assert.Equal(t, metricSpec[0].Resource.Target.Type, v2.UtilizationMetricType)
 }
 
 func TestGetContainerMetricSpecForScaling(t *testing.T) {
@@ -90,21 +90,21 @@ func TestGetContainerMetricSpecForScaling(t *testing.T) {
 	scaler, _ := NewCPUMemoryScaler(v1.ResourceCPU, config)
 	metricSpec := scaler.GetMetricSpecForScaling(context.Background())
 
-	assert.Equal(t, metricSpec[0].Type, v2beta2.ContainerResourceMetricSourceType)
+	assert.Equal(t, metricSpec[0].Type, v2.ContainerResourceMetricSourceType)
 	assert.Equal(t, metricSpec[0].ContainerResource.Name, v1.ResourceCPU)
-	assert.Equal(t, metricSpec[0].ContainerResource.Target.Type, v2beta2.UtilizationMetricType)
+	assert.Equal(t, metricSpec[0].ContainerResource.Target.Type, v2.UtilizationMetricType)
 	assert.Equal(t, metricSpec[0].ContainerResource.Container, validContainerCPUMemoryMetadata["containerName"])
 
 	// Using trigger.metricType field for type
 	config = &ScalerConfig{
 		TriggerMetadata: map[string]string{"value": "50", "containerName": "bar"},
-		MetricType:      v2beta2.UtilizationMetricType,
+		MetricType:      v2.UtilizationMetricType,
 	}
 	scaler, _ = NewCPUMemoryScaler(v1.ResourceCPU, config)
 	metricSpec = scaler.GetMetricSpecForScaling(context.Background())
 
-	assert.Equal(t, metricSpec[0].Type, v2beta2.ContainerResourceMetricSourceType)
+	assert.Equal(t, metricSpec[0].Type, v2.ContainerResourceMetricSourceType)
 	assert.Equal(t, metricSpec[0].ContainerResource.Name, v1.ResourceCPU)
-	assert.Equal(t, metricSpec[0].ContainerResource.Target.Type, v2beta2.UtilizationMetricType)
+	assert.Equal(t, metricSpec[0].ContainerResource.Target.Type, v2.UtilizationMetricType)
 	assert.Equal(t, metricSpec[0].ContainerResource.Container, "bar")
 }

--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/robfig/cron/v3"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -22,7 +22,7 @@ const (
 )
 
 type cronScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *cronMetadata
 	logger     logr.Logger
 }
@@ -157,16 +157,16 @@ func parseCronTimeFormat(s string) string {
 }
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
-func (s *cronScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *cronScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	var specReplicas int64 = 1
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("cron-%s-%s-%s", s.metadata.timezone, parseCronTimeFormat(s.metadata.start), parseCronTimeFormat(s.metadata.end)))),
 		},
 		Target: GetMetricTarget(s.metricType, specReplicas),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: cronMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: cronMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics finds the current value of the metric

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -10,7 +10,7 @@ import (
 
 	datadog "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 	"github.com/go-logr/logr"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -31,7 +31,7 @@ type datadogMetadata struct {
 	queryValue               float64
 	queryAggegrator          string
 	activationQueryValue     float64
-	vType                    v2beta2.MetricTargetType
+	vType                    v2.MetricTargetType
 	metricName               string
 	age                      int
 	timeWindowOffset         int
@@ -185,9 +185,9 @@ func parseDatadogMetadata(config *ScalerConfig, logger logr.Logger) (*datadogMet
 		val = strings.ToLower(val)
 		switch val {
 		case avgString:
-			meta.vType = v2beta2.AverageValueMetricType
+			meta.vType = v2.AverageValueMetricType
 		case "global":
-			meta.vType = v2beta2.ValueMetricType
+			meta.vType = v2.ValueMetricType
 		default:
 			return nil, fmt.Errorf("type has to be global or average")
 		}
@@ -371,17 +371,17 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *datadogScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *datadogScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: s.metadata.metricName,
 		},
 		Target: GetMetricTargetMili(s.metadata.vType, s.metadata.queryValue),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 )
 
 type datadogQueries struct {
@@ -21,7 +21,7 @@ type datadogMetricIdentifier struct {
 }
 
 type datadogAuthMetadataTestData struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   map[string]string
 	authParams map[string]string
 	isError    bool
@@ -106,7 +106,7 @@ var testDatadogMetadata = []datadogAuthMetadataTestData{
 	// wrong type
 	{"", map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "invalid", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 	// both metadata type and trigger type
-	{v2beta2.AverageValueMetricType, map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
+	{v2.AverageValueMetricType, map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 	// missing query
 	{"", map[string]string{"queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 	// missing queryValue

--- a/pkg/scalers/elasticsearch_scaler.go
+++ b/pkg/scalers/elasticsearch_scaler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/go-logr/logr"
 	"github.com/tidwall/gjson"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -22,7 +22,7 @@ import (
 )
 
 type elasticsearchScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *elasticsearchMetadata
 	esClient   *elasticsearch.Client
 	logger     logr.Logger
@@ -249,17 +249,17 @@ func getValueFromSearch(body []byte, valueLocation string) (float64, error) {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *elasticsearchScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *elasticsearchScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: s.metadata.metricName,
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.targetValue),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/external_mock_scaler.go
+++ b/pkg/scalers/external_mock_scaler.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"sync/atomic"
 
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -46,7 +46,7 @@ func (*externalMockScaler) Close(ctx context.Context) error {
 }
 
 // GetMetricSpecForScaling implements Scaler
-func (*externalMockScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
+func (*externalMockScaler) GetMetricSpecForScaling(ctx context.Context) []v2.MetricSpec {
 	if atomic.LoadInt32(&MockExternalServerStatus) != MockExternalServerStatusOnline {
 		return nil
 	}
@@ -63,16 +63,16 @@ func (*externalMockScaler) GetMetrics(ctx context.Context, metricName string, me
 	return getMockExternalMetricsValue(), nil
 }
 
-func getMockMetricsSpecs() []v2beta2.MetricSpec {
-	return []v2beta2.MetricSpec{
+func getMockMetricsSpecs() []v2.MetricSpec {
+	return []v2.MetricSpec{
 		{
-			Type: v2beta2.ExternalMetricSourceType,
-			External: &v2beta2.ExternalMetricSource{
-				Metric: v2beta2.MetricIdentifier{
+			Type: v2.ExternalMetricSourceType,
+			External: &v2.ExternalMetricSource{
+				Metric: v2.MetricIdentifier{
 					Name: MockMetricName,
 				},
-				Target: v2beta2.MetricTarget{
-					Type:  v2beta2.ValueMetricType,
+				Target: v2.MetricTarget{
+					Type:  v2.ValueMetricType,
 					Value: resource.NewQuantity(MockMetricValue, resource.DecimalSI),
 				},
 			},

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -21,7 +21,7 @@ import (
 )
 
 type externalScaler struct {
-	metricType      v2beta2.MetricTargetType
+	metricType      v2.MetricTargetType
 	metadata        externalScalerMetadata
 	scaledObjectRef pb.ScaledObjectRef
 	logger          logr.Logger
@@ -150,8 +150,8 @@ func (s *externalScaler) Close(context.Context) error {
 }
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
-func (s *externalScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
-	var result []v2beta2.MetricSpec
+func (s *externalScaler) GetMetricSpecForScaling(ctx context.Context) []v2.MetricSpec {
+	var result []v2.MetricSpec
 
 	grpcClient, err := getClientForConnectionPool(s.metadata)
 	if err != nil {
@@ -166,15 +166,15 @@ func (s *externalScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.
 	}
 
 	for _, spec := range response.MetricSpecs {
-		externalMetric := &v2beta2.ExternalMetricSource{
-			Metric: v2beta2.MetricIdentifier{
+		externalMetric := &v2.ExternalMetricSource{
+			Metric: v2.MetricIdentifier{
 				Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, spec.MetricName),
 			},
 			Target: GetMetricTarget(s.metricType, spec.TargetSize),
 		}
 
 		// Create the metric spec for the HPA
-		metricSpec := v2beta2.MetricSpec{
+		metricSpec := v2.MetricSpec{
 			External: externalMetric,
 			Type:     externalMetricType,
 		}

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -31,7 +31,7 @@ var regexpCompositeSubscriptionIDPrefix = regexp.MustCompile(compositeSubscripti
 
 type pubsubScaler struct {
 	client     *StackDriverClient
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *pubsubMetadata
 	logger     logr.Logger
 }
@@ -171,21 +171,21 @@ func (s *pubsubScaler) Close(context.Context) error {
 }
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
-func (s *pubsubScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *pubsubScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("gcp-ps-%s", s.metadata.subscriptionName))),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.value),
 	}
 
 	// Create the metric spec for the HPA
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric,
 		Type:     externalMetricType,
 	}
 
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics connects to Stack Driver and finds the size of the pub sub subscription

--- a/pkg/scalers/gcp_stackdriver_scaler.go
+++ b/pkg/scalers/gcp_stackdriver_scaler.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -20,7 +20,7 @@ const (
 
 type stackdriverScaler struct {
 	client     *StackDriverClient
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *stackdriverMetadata
 	logger     logr.Logger
 }
@@ -184,21 +184,21 @@ func (s *stackdriverScaler) Close(context.Context) error {
 }
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
-func (s *stackdriverScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *stackdriverScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: s.metadata.metricName,
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.targetValue),
 	}
 
 	// Create the metric spec for the HPA
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric,
 		Type:     externalMetricType,
 	}
 
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics connects to Stack Driver and retrieves the metric

--- a/pkg/scalers/gcp_storage_scaler.go
+++ b/pkg/scalers/gcp_storage_scaler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	"google.golang.org/api/iterator"
 	option "google.golang.org/api/option"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -27,7 +27,7 @@ const (
 type gcsScaler struct {
 	client     *storage.Client
 	bucket     *storage.BucketHandle
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *gcsMetadata
 	logger     logr.Logger
 }
@@ -166,15 +166,15 @@ func (s *gcsScaler) Close(context.Context) error {
 }
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
-func (s *gcsScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *gcsScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: s.metadata.metricName,
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetObjectCount),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns the number of items in the bucket (up to s.metadata.maxBucketItemsToScan)

--- a/pkg/scalers/graphite_scaler.go
+++ b/pkg/scalers/graphite_scaler.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -29,7 +29,7 @@ const (
 )
 
 type graphiteScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *graphiteMetadata
 	httpClient *http.Client
 	logger     logr.Logger
@@ -163,17 +163,17 @@ func (s *graphiteScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *graphiteScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *graphiteScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("graphite-%s", s.metadata.metricName))),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.threshold),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *graphiteScaler) executeGrapQuery(ctx context.Context) (float64, error) {

--- a/pkg/scalers/huawei_cloudeye_scaler.go
+++ b/pkg/scalers/huawei_cloudeye_scaler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Huawei/gophercloud/openstack"
 	"github.com/Huawei/gophercloud/openstack/ces/v1/metricdata"
 	"github.com/go-logr/logr"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -27,7 +27,7 @@ const (
 )
 
 type huaweiCloudeyeScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *huaweiCloudeyeMetadata
 	logger     logr.Logger
 }
@@ -253,15 +253,15 @@ func (s *huaweiCloudeyeScaler) GetMetrics(ctx context.Context, metricName string
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (s *huaweiCloudeyeScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *huaweiCloudeyeScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("huawei-cloudeye-%s", s.metadata.metricsName))),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.targetMetricValue),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *huaweiCloudeyeScaler) IsActive(ctx context.Context) (bool, error) {

--- a/pkg/scalers/ibmmq_scaler.go
+++ b/pkg/scalers/ibmmq_scaler.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -28,7 +28,7 @@ const (
 
 // IBMMQScaler assigns struct data pointer to metadata variable
 type IBMMQScaler struct {
-	metricType         v2beta2.MetricTargetType
+	metricType         v2.MetricTargetType
 	metadata           *IBMMQMetadata
 	defaultHTTPTimeout time.Duration
 	logger             logr.Logger
@@ -218,15 +218,15 @@ func (s *IBMMQScaler) getQueueDepthViaHTTP(ctx context.Context) (int64, error) {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *IBMMQScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *IBMMQScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("ibmmq-%s", s.metadata.queueName))),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.queueDepth),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	api "github.com/influxdata/influxdb-client-go/v2/api"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -18,7 +18,7 @@ import (
 
 type influxDBScaler struct {
 	client     influxdb2.Client
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *influxDBMetadata
 	logger     logr.Logger
 }
@@ -223,15 +223,15 @@ func (s *influxDBScaler) GetMetrics(ctx context.Context, metricName string, metr
 }
 
 // GetMetricSpecForScaling returns the metric spec for the Horizontal Pod Autoscaler
-func (s *influxDBScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *influxDBScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, s.metadata.metricName),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.thresholdValue),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -18,7 +18,7 @@ import (
 )
 
 type kafkaScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   kafkaMetadata
 	client     sarama.Client
 	admin      sarama.ClusterAdmin
@@ -427,7 +427,7 @@ func (s *kafkaScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *kafkaScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *kafkaScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	var metricName string
 	if s.metadata.topic != "" {
 		metricName = fmt.Sprintf("kafka-%s", s.metadata.topic)
@@ -435,14 +435,14 @@ func (s *kafkaScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricS
 		metricName = fmt.Sprintf("kafka-%s-topics", s.metadata.group)
 	}
 
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(metricName)),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.lagThreshold),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: kafkaMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: kafkaMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 type consumerOffsetResult struct {

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -16,7 +16,7 @@ import (
 )
 
 type kubernetesWorkloadScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *kubernetesWorkloadMetadata
 	kubeClient client.Client
 	logger     logr.Logger
@@ -104,15 +104,15 @@ func (s *kubernetesWorkloadScaler) Close(context.Context) error {
 }
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
-func (s *kubernetesWorkloadScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *kubernetesWorkloadScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("workload-%s", s.metadata.namespace))),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.value),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: kubernetesWorkloadMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: kubernetesWorkloadMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -19,7 +19,7 @@ import (
 )
 
 type liiklusScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *liiklusMetadata
 	connection *grpc.ClientConn
 	client     liiklus_service.LiiklusServiceClient
@@ -90,15 +90,15 @@ func (s *liiklusScaler) GetMetrics(ctx context.Context, metricName string, metri
 	}, nil
 }
 
-func (s *liiklusScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *liiklusScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("liiklus-%s", s.metadata.topic))),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.lagThreshold),
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: liiklusMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: liiklusMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *liiklusScaler) Close(context.Context) error {

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/tidwall/gjson"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -22,7 +22,7 @@ import (
 )
 
 type metricsAPIScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *metricsAPIScalerMetadata
 	client     *http.Client
 	logger     logr.Logger
@@ -260,17 +260,17 @@ func (s *metricsAPIScaler) IsActive(ctx context.Context) (bool, error) {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *metricsAPIScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *metricsAPIScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("metric-api-%s", s.metadata.valueLocation))),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.targetValue),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/mongo_scaler.go
+++ b/pkg/scalers/mongo_scaler.go
@@ -15,7 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/x/bsonx"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -24,7 +24,7 @@ import (
 
 // mongoDBScaler is support for mongoDB in keda.
 type mongoDBScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *mongoDBMetadata
 	client     *mongo.Client
 	logger     logr.Logger
@@ -262,17 +262,17 @@ func (s *mongoDBScaler) GetMetrics(ctx context.Context, metricName string, _ lab
 }
 
 // GetMetricSpecForScaling get the query value for scaling
-func (s *mongoDBScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *mongoDBScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, s.metadata.metricName),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.queryValue),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // json2BsonDoc convert Json to Bson.Doc

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -10,7 +10,7 @@ import (
 	// mssql driver required for this scaler
 	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -19,7 +19,7 @@ import (
 
 // mssqlScaler exposes a data pointer to mssqlMetadata and sql.DB connection
 type mssqlScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *mssqlMetadata
 	connection *sql.DB
 	logger     logr.Logger
@@ -229,19 +229,19 @@ func getMSSQLConnectionString(meta *mssqlMetadata) string {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *mssqlScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *mssqlScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, s.metadata.metricName),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.targetValue),
 	}
 
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
 
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns a value for a supported metric or an error if there is a problem getting the metric

--- a/pkg/scalers/mysql_scaler.go
+++ b/pkg/scalers/mysql_scaler.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-sql-driver/mysql"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -17,7 +17,7 @@ import (
 )
 
 type mySQLScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *mySQLMetadata
 	connection *sql.DB
 	logger     logr.Logger
@@ -215,17 +215,17 @@ func (s *mySQLScaler) getQueryResult(ctx context.Context) (float64, error) {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *mySQLScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *mySQLScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: s.metadata.metricName,
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.queryValue),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/nats_jetstream_scaler.go
+++ b/pkg/scalers/nats_jetstream_scaler.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -24,7 +24,7 @@ const (
 )
 
 type natsJetStreamScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	stream     *streamDetail
 	metadata   natsJetStreamMetadata
 	httpClient *http.Client
@@ -201,18 +201,18 @@ func (s *natsJetStreamScaler) getMaxMsgLag() int64 {
 	return s.stream.State.LastSequence
 }
 
-func (s *natsJetStreamScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *natsJetStreamScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	metricName := kedautil.NormalizeString(fmt.Sprintf("nats-jetstream-%s", s.metadata.stream))
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.lagThreshold),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: jetStreamMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *natsJetStreamScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {

--- a/pkg/scalers/newrelic_scaler.go
+++ b/pkg/scalers/newrelic_scaler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/newrelic/newrelic-client-go/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/nrdb"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -27,7 +27,7 @@ const (
 )
 
 type newrelicScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *newrelicMetadata
 	nrClient   *newrelic.NewRelic
 	logger     logr.Logger
@@ -186,17 +186,17 @@ func (s *newrelicScaler) GetMetrics(ctx context.Context, metricName string, metr
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (s *newrelicScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *newrelicScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	metricName := kedautil.NormalizeString(scalerName)
 
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.threshold),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }

--- a/pkg/scalers/openstack_metrics_scaler.go
+++ b/pkg/scalers/openstack_metrics_scaler.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -47,7 +47,7 @@ type openstackMetricAuthenticationMetadata struct {
 }
 
 type openstackMetricScaler struct {
-	metricType   v2beta2.MetricTargetType
+	metricType   v2.MetricTargetType
 	metadata     *openstackMetricMetadata
 	metricClient openstack.Client
 	logger       logr.Logger
@@ -215,22 +215,22 @@ func parseOpenstackMetricAuthenticationMetadata(config *ScalerConfig) (openstack
 	return authMeta, nil
 }
 
-func (s *openstackMetricScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *openstackMetricScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	metricName := kedautil.NormalizeString(fmt.Sprintf("openstack-metric-%s", s.metadata.metricID))
 
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.threshold),
 	}
 
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric,
 		Type:     externalMetricType,
 	}
 
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *openstackMetricScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {

--- a/pkg/scalers/openstack_swift_scaler.go
+++ b/pkg/scalers/openstack_swift_scaler.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -53,7 +53,7 @@ type openstackSwiftAuthenticationMetadata struct {
 }
 
 type openstackSwiftScaler struct {
-	metricType  v2beta2.MetricTargetType
+	metricType  v2.MetricTargetType
 	metadata    *openstackSwiftMetadata
 	swiftClient openstack.Client
 	logger      logr.Logger
@@ -396,7 +396,7 @@ func (s *openstackSwiftScaler) GetMetrics(ctx context.Context, metricName string
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (s *openstackSwiftScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *openstackSwiftScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	var metricName string
 
 	if s.metadata.objectPrefix != "" {
@@ -407,16 +407,16 @@ func (s *openstackSwiftScaler) GetMetricSpecForScaling(context.Context) []v2beta
 
 	metricName = kedautil.NormalizeString(fmt.Sprintf("openstack-swift-%s", metricName))
 
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.objectCount),
 	}
 
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
 
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }

--- a/pkg/scalers/postgresql_scaler.go
+++ b/pkg/scalers/postgresql_scaler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	// PostreSQL drive required for this scaler
 	_ "github.com/lib/pq"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -17,7 +17,7 @@ import (
 )
 
 type postgreSQLScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *postgreSQLMetadata
 	connection *sql.DB
 	logger     logr.Logger
@@ -189,17 +189,17 @@ func (s *postgreSQLScaler) getActiveNumber(ctx context.Context) (float64, error)
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *postgreSQLScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *postgreSQLScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, s.metadata.metricName),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.targetQueryValue),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/predictkube_scaler.go
+++ b/pkg/scalers/predictkube_scaler.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	health "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -74,7 +74,7 @@ var (
 )
 
 type PredictKubeScaler struct {
-	metricType       v2beta2.MetricTargetType
+	metricType       v2.MetricTargetType
 	metadata         *predictKubeMetadata
 	prometheusClient api.Client
 	grpcConn         *grpc.ClientConn
@@ -205,19 +205,19 @@ func (s *PredictKubeScaler) Close(_ context.Context) error {
 	return nil
 }
 
-func (s *PredictKubeScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *PredictKubeScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	metricName := kedautil.NormalizeString(fmt.Sprintf("predictkube-%s", predictKubeMetricPrefix))
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.threshold),
 	}
 
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: predictKubeMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *PredictKubeScaler) GetMetrics(ctx context.Context, metricName string, _ labels.Selector) ([]external_metrics.ExternalMetricValue, error) {

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -37,7 +37,7 @@ var (
 )
 
 type prometheusScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *prometheusMetadata
 	httpClient *http.Client
 	logger     logr.Logger
@@ -192,18 +192,18 @@ func (s *prometheusScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *prometheusScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *prometheusScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	metricName := kedautil.NormalizeString(fmt.Sprintf("prometheus-%s", s.metadata.metricName))
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.threshold),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *prometheusScaler) ExecutePromQuery(ctx context.Context) (float64, error) {

--- a/pkg/scalers/pulsar_scaler.go
+++ b/pkg/scalers/pulsar_scaler.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -273,20 +273,20 @@ func (s *pulsarScaler) GetMetrics(ctx context.Context, metricName string, _ labe
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (s *pulsarScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *pulsarScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(s.metadata.msgBacklogThreshold, resource.DecimalSI)
 
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(s.metadata.metricName)),
 		},
-		Target: v2beta2.MetricTarget{
-			Type:         v2beta2.AverageValueMetricType,
+		Target: v2.MetricTarget{
+			Type:         v2.AverageValueMetricType,
 			AverageValue: targetMetricValue,
 		},
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: pulsarMetricType}
-	return []v2beta2.MetricSpec{metricSpec}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: pulsarMetricType}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *pulsarScaler) Close(context.Context) error {

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/streadway/amqp"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -53,7 +53,7 @@ const (
 )
 
 type rabbitMQScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *rabbitMQMetadata
 	connection *amqp.Connection
 	channel    *amqp.Channel
@@ -486,18 +486,18 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *rabbitMQScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+func (s *rabbitMQScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, s.metadata.metricName),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.value),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: rabbitMetricType,
 	}
 
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/scaler_test.go
+++ b/pkg/scalers/scaler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -13,31 +13,31 @@ func TestGetMetricTargetType(t *testing.T) {
 	cases := []struct {
 		name           string
 		config         *ScalerConfig
-		wantmetricType v2beta2.MetricTargetType
+		wantmetricType v2.MetricTargetType
 		wantErr        error
 	}{
 		{
 			name:           "utilization metric type",
-			config:         &ScalerConfig{MetricType: v2beta2.UtilizationMetricType},
+			config:         &ScalerConfig{MetricType: v2.UtilizationMetricType},
 			wantmetricType: "",
 			wantErr:        fmt.Errorf("'Utilization' metric type is unsupported for external metrics, allowed values are 'Value' or 'AverageValue'"),
 		},
 		{
 			name:           "average value metric type",
-			config:         &ScalerConfig{MetricType: v2beta2.AverageValueMetricType},
-			wantmetricType: v2beta2.AverageValueMetricType,
+			config:         &ScalerConfig{MetricType: v2.AverageValueMetricType},
+			wantmetricType: v2.AverageValueMetricType,
 			wantErr:        nil,
 		},
 		{
 			name:           "value metric type",
-			config:         &ScalerConfig{MetricType: v2beta2.ValueMetricType},
-			wantmetricType: v2beta2.ValueMetricType,
+			config:         &ScalerConfig{MetricType: v2.ValueMetricType},
+			wantmetricType: v2.ValueMetricType,
 			wantErr:        nil,
 		},
 		{
 			name:           "no metric type",
 			config:         &ScalerConfig{},
-			wantmetricType: v2beta2.AverageValueMetricType,
+			wantmetricType: v2.AverageValueMetricType,
 			wantErr:        nil,
 		},
 	}
@@ -59,21 +59,21 @@ func TestGetMetricTargetType(t *testing.T) {
 func TestGetMetricTarget(t *testing.T) {
 	cases := []struct {
 		name             string
-		metricType       v2beta2.MetricTargetType
+		metricType       v2.MetricTargetType
 		metricValue      int64
-		wantmetricTarget v2beta2.MetricTarget
+		wantmetricTarget v2.MetricTarget
 	}{
 		{
 			name:             "average value metric type",
-			metricType:       v2beta2.AverageValueMetricType,
+			metricType:       v2.AverageValueMetricType,
 			metricValue:      10,
-			wantmetricTarget: v2beta2.MetricTarget{Type: v2beta2.AverageValueMetricType, AverageValue: resource.NewQuantity(10, resource.DecimalSI)},
+			wantmetricTarget: v2.MetricTarget{Type: v2.AverageValueMetricType, AverageValue: resource.NewQuantity(10, resource.DecimalSI)},
 		},
 		{
 			name:             "value metric type",
-			metricType:       v2beta2.ValueMetricType,
+			metricType:       v2.ValueMetricType,
 			metricValue:      20,
-			wantmetricTarget: v2beta2.MetricTarget{Type: v2beta2.ValueMetricType, Value: resource.NewQuantity(20, resource.DecimalSI)},
+			wantmetricTarget: v2.MetricTarget{Type: v2.ValueMetricType, Value: resource.NewQuantity(20, resource.DecimalSI)},
 		},
 	}
 

--- a/pkg/scalers/selenium_grid_scaler.go
+++ b/pkg/scalers/selenium_grid_scaler.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -21,7 +21,7 @@ import (
 )
 
 type seleniumGridScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *seleniumGridScalerMetadata
 	client     *http.Client
 	logger     logr.Logger
@@ -162,18 +162,18 @@ func (s *seleniumGridScaler) GetMetrics(ctx context.Context, metricName string, 
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (s *seleniumGridScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *seleniumGridScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	metricName := kedautil.NormalizeString(fmt.Sprintf("seleniumgrid-%s", s.metadata.browserName))
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.targetValue),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 func (s *seleniumGridScaler) IsActive(ctx context.Context) (bool, error) {

--- a/pkg/scalers/solace_scaler.go
+++ b/pkg/scalers/solace_scaler.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -58,7 +58,7 @@ type SolaceMetricValues struct {
 }
 
 type SolaceScaler struct {
-	metricType v2beta2.MetricTargetType
+	metricType v2.MetricTargetType
 	metadata   *SolaceMetadata
 	httpClient *http.Client
 	logger     logr.Logger
@@ -271,30 +271,30 @@ func getSolaceSempCredentials(config *ScalerConfig) (u string, p string, err err
 // METRIC IDENTIFIER HAS THE SIGNATURE:
 // - solace-[Queue_Name]-[metric_type]
 // e.g. solace-QUEUE1-msgCount
-func (s *SolaceScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	var metricSpecList []v2beta2.MetricSpec
+func (s *SolaceScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	var metricSpecList []v2.MetricSpec
 	// Message Count Target Spec
 	if s.metadata.msgCountTarget > 0 {
 		metricName := kedautil.NormalizeString(fmt.Sprintf("solace-%s-%s", s.metadata.queueName, solaceTriggermsgcount))
-		externalMetric := &v2beta2.ExternalMetricSource{
-			Metric: v2beta2.MetricIdentifier{
+		externalMetric := &v2.ExternalMetricSource{
+			Metric: v2.MetricIdentifier{
 				Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
 			},
 			Target: GetMetricTarget(s.metricType, s.metadata.msgCountTarget),
 		}
-		metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: solaceExtMetricType}
+		metricSpec := v2.MetricSpec{External: externalMetric, Type: solaceExtMetricType}
 		metricSpecList = append(metricSpecList, metricSpec)
 	}
 	// Message Spool Usage Target Spec
 	if s.metadata.msgSpoolUsageTarget > 0 {
 		metricName := kedautil.NormalizeString(fmt.Sprintf("solace-%s-%s", s.metadata.queueName, solaceTriggermsgspoolusage))
-		externalMetric := &v2beta2.ExternalMetricSource{
-			Metric: v2beta2.MetricIdentifier{
+		externalMetric := &v2.ExternalMetricSource{
+			Metric: v2.MetricIdentifier{
 				Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
 			},
 			Target: GetMetricTarget(s.metricType, s.metadata.msgSpoolUsageTarget),
 		}
-		metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: solaceExtMetricType}
+		metricSpec := v2.MetricSpec{External: externalMetric, Type: solaceExtMetricType}
 		metricSpecList = append(metricSpecList, metricSpec)
 	}
 	return metricSpecList

--- a/pkg/scalers/solace_scaler_test.go
+++ b/pkg/scalers/solace_scaler_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 )
 
 type testSolaceMetadata struct {
@@ -467,7 +467,7 @@ func TestSolaceGetMetricSpec(t *testing.T) {
 				httpClient: http.DefaultClient,
 			}
 
-			var metric []v2beta2.MetricSpec
+			var metric []v2.MetricSpec
 			if metric = testSolaceScaler.GetMetricSpecForScaling(context.Background()); len(metric) == 0 {
 				err = fmt.Errorf("metric value not found")
 			} else {

--- a/pkg/scalers/stan_scaler.go
+++ b/pkg/scalers/stan_scaler.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -38,7 +38,7 @@ type monitorSubscriberInfo struct {
 
 type stanScaler struct {
 	channelInfo *monitorChannelInfo
-	metricType  v2beta2.MetricTargetType
+	metricType  v2.MetricTargetType
 	metadata    stanMetadata
 	httpClient  *http.Client
 	logger      logr.Logger
@@ -211,18 +211,18 @@ func (s *stanScaler) hasPendingMessage() bool {
 	return false
 }
 
-func (s *stanScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *stanScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	metricName := kedautil.NormalizeString(fmt.Sprintf("stan-%s", s.metadata.subject))
-	externalMetric := &v2beta2.ExternalMetricSource{
-		Metric: v2beta2.MetricIdentifier{
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
 		},
 		Target: GetMetricTarget(s.metricType, s.metadata.lagThreshold),
 	}
-	metricSpec := v2beta2.MetricSpec{
+	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: stanMetricType,
 	}
-	return []v2beta2.MetricSpec{metricSpec}
+	return []v2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -22,7 +22,7 @@ import (
 	"math"
 
 	"github.com/go-logr/logr"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
@@ -216,8 +216,8 @@ func (c *ScalersCache) refreshScaler(ctx context.Context, id int) (scalers.Scale
 	return ns, nil
 }
 
-func (c *ScalersCache) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
-	var spec []v2beta2.MetricSpec
+func (c *ScalersCache) GetMetricSpecForScaling(ctx context.Context) []v2.MetricSpec {
+	var spec []v2.MetricSpec
 	for _, s := range c.Scalers {
 		spec = append(spec, s.Scaler.GetMetricSpecForScaling(ctx)...)
 	}
@@ -311,7 +311,7 @@ func (c *ScalersCache) getScaledJobMetrics(ctx context.Context, scaledJob *kedav
 	return scalersMetrics
 }
 
-func getTargetAverageValue(metricSpecs []v2beta2.MetricSpec) float64 {
+func getTargetAverageValue(metricSpecs []v2.MetricSpec) float64 {
 	var targetAverageValue float64
 	var metricValue float64
 	for _, metric := range metricSpecs {

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -20,19 +20,19 @@ import (
 
 func TestTargetAverageValue(t *testing.T) {
 	// count = 0
-	specs := []v2beta2.MetricSpec{}
+	specs := []v2.MetricSpec{}
 	metricName := "s0-messageCount"
 	targetAverageValue := getTargetAverageValue(specs)
 	assert.Equal(t, float64(0), targetAverageValue)
 	// 1 1
-	specs = []v2beta2.MetricSpec{
+	specs = []v2.MetricSpec{
 		createMetricSpec(1, metricName),
 		createMetricSpec(1, metricName),
 	}
 	targetAverageValue = getTargetAverageValue(specs)
 	assert.Equal(t, float64(1), targetAverageValue)
 	// 5 5 3 -> 4.333333333333333
-	specs = []v2beta2.MetricSpec{
+	specs = []v2.MetricSpec{
 		createMetricSpec(5, metricName),
 		createMetricSpec(5, metricName),
 		createMetricSpec(3, metricName),
@@ -41,7 +41,7 @@ func TestTargetAverageValue(t *testing.T) {
 	assert.Equal(t, 4.333333333333333, targetAverageValue)
 
 	// 5 5 4 -> 4.666666666666667
-	specs = []v2beta2.MetricSpec{
+	specs = []v2.MetricSpec{
 		createMetricSpec(5, metricName),
 		createMetricSpec(5, metricName),
 		createMetricSpec(4, metricName),
@@ -50,14 +50,14 @@ func TestTargetAverageValue(t *testing.T) {
 	assert.Equal(t, 4.666666666666667, targetAverageValue)
 }
 
-func createMetricSpec(averageValue int64, metricName string) v2beta2.MetricSpec {
+func createMetricSpec(averageValue int64, metricName string) v2.MetricSpec {
 	qty := resource.NewQuantity(averageValue, resource.DecimalSI)
-	return v2beta2.MetricSpec{
-		External: &v2beta2.ExternalMetricSource{
-			Target: v2beta2.MetricTarget{
+	return v2.MetricSpec{
+		External: &v2.ExternalMetricSource{
+			Target: v2.MetricTarget{
 				AverageValue: qty,
 			},
-			Metric: v2beta2.MetricIdentifier{
+			Metric: v2.MetricIdentifier{
 				Name: metricName,
 			},
 		},
@@ -270,7 +270,7 @@ func createScaledObject(minReplicaCount int32, maxReplicaCount int32, multipleSc
 
 func createScaler(ctrl *gomock.Controller, queueLength int64, averageValue int64, isActive bool, metricName string) *mock_scalers.MockScaler {
 	scaler := mock_scalers.NewMockScaler(ctrl)
-	metricsSpecs := []v2beta2.MetricSpec{createMetricSpec(averageValue, metricName)}
+	metricsSpecs := []v2.MetricSpec{createMetricSpec(averageValue, metricName)}
 
 	metrics := []external_metrics.ExternalMetricValue{
 		{

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -80,7 +80,7 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	recorder := record.NewFakeRecorder(1)
 
-	metricsSpecs := []v2beta2.MetricSpec{createMetricSpec(1)}
+	metricsSpecs := []v2.MetricSpec{createMetricSpec(1)}
 
 	activeFactory := func() (scalers.Scaler, error) {
 		scaler := mock_scalers.NewMockScaler(ctrl)
@@ -134,11 +134,11 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 	assert.Equal(t, true, isError)
 }
 
-func createMetricSpec(averageValue int64) v2beta2.MetricSpec {
+func createMetricSpec(averageValue int64) v2.MetricSpec {
 	qty := resource.NewQuantity(averageValue, resource.DecimalSI)
-	return v2beta2.MetricSpec{
-		External: &v2beta2.ExternalMetricSource{
-			Target: v2beta2.MetricTarget{
+	return v2.MetricSpec{
+		External: &v2.ExternalMetricSource{
+			Target: v2.MetricTarget{
 				AverageValue: qty,
 			},
 		},

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -375,11 +375,11 @@ func AssertReplicaCountNotChangeDuringTimePeriod(t *testing.T, kc *kubernetes.Cl
 }
 
 func WaitForHpaCreation(t *testing.T, kc *kubernetes.Clientset, name, namespace string,
-	iterations, intervalSeconds int) (*autoscalingv2beta2.HorizontalPodAutoscaler, error) {
-	hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+	iterations, intervalSeconds int) (*autoscalingv2.HorizontalPodAutoscaler, error) {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 	var err error
 	for i := 0; i < iterations; i++ {
-		hpa, err = kc.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		hpa, err = kc.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		t.Log("Waiting for hpa creation")
 		if err == nil {
 			return hpa, err


### PR DESCRIPTION
autoscaling/v2beta2 was deprecated in k8s 1.23 and removed in 1.26.  This PR switches from v2beta2 to v2 which will allow CMA to run on OpenShift 4.13.