### PR TITLE
Re-add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - joelsmith
+  - rphillips
+  - zroubalik
+
+# Bugzilla fields:
+component: Node


### PR DESCRIPTION
The OWNERS file was accidentally deleted during the rebase since
its commit message was missing the obligatory `UPSTREAM: <carry>:` prefix

Original commit is 77b3563713b1d29b88dfdf3bd1a1cdfa3b5edd3c