### PR TITLE
OCPBUGS-15274: Check for "none" when checking pod identity provider

### DIFF
--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -15,6 +15,7 @@ import (
 	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/scalers/authentication"
 	"github.com/kedacore/keda/v2/pkg/scalers/azure"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
@@ -227,7 +228,7 @@ func parseAuthConfig(config *ScalerConfig, meta *prometheusMetadata) error {
 		return err
 	}
 
-	if auth != nil && config.PodIdentity.Provider != "" {
+	if auth != nil && !(config.PodIdentity.Provider == kedav1alpha1.PodIdentityProviderNone || config.PodIdentity.Provider == "") {
 		return fmt.Errorf("pod identity cannot be enabled with other auth types")
 	}
 	meta.prometheusAuth = auth


### PR DESCRIPTION
Cherry-pick of upstream https://github.com/kedacore/keda/pull/4748