### PR TITLE
PODAUTO-96: Exclude vendor and tests from snyk scans to reduce noise

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,5 @@
+exclude:
+  global:
+    - "vendor/**"
+    - "**/*_test.go"
+    - "tests/**"  # contains test code that does not end in _test.go


### PR DESCRIPTION
We've been getting a lot of noise on snyk scans from deps and tests, so for now we need to exclude those files.

NOTE: this one also explicitly excludes `tests/` because it's entirely used for testing, and there are test launchers in there that are test code that doesn't end in` _test.go` 