### PR TITLE
UPSTREAM: 6010: reassign err to prevent invalid return in KedaProvider `GetExternalMetric`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,9 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix CVE-2024-24790, CVE-2024-24789, and CVE-2024-24791 in stdlib. ([#5971](https://github.com/kedacore/keda/pull/5971))
 - **General**: Fix CVE-2024-35255 in github.com/Azure/azure-sdk-for-go/sdk/azidentity ([#5971](https://github.com/kedacore/keda/pull/5971))
 - **General**: Fix CVE-2024-6104 in github.com/hashicorp/go-retryablehttp ([#5971](https://github.com/kedacore/keda/pull/5971))
-- **General**: Fix ScaledJob ignores failing trigger(s) error ([#5922](https://github.com/kedacore/keda/issues/5922))- **General**: Scalers are properly closed after being refreshed ([#5806](https://github.com/kedacore/keda/issues/5806))
+- **General**: Fix panic in `KedaProvider` when getting metrics from Metrics Service if the gRPC Server connection is not established ([#6009](https://github.com/kedacore/keda/issues/6009))
+- **General**: Fix ScaledJob ignores failing trigger(s) error ([#5922](https://github.com/kedacore/keda/issues/5922))
+- **General**: Scalers are properly closed after being refreshed ([#5806](https://github.com/kedacore/keda/issues/5806))
 - **GitHub Scaler**: Fixed pagination, fetching repository list ([#5738](https://github.com/kedacore/keda/issues/5738))
 - **MongoDB Scaler**:  MongoDB url parses correctly `+srv` scheme ([#5760](https://github.com/kedacore/keda/issues/5760))
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -86,7 +86,8 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 	// Get Metrics from Metrics Service gRPC Server
 	if !p.grpcClient.WaitForConnectionReady(ctx, logger) {
 		grpcClientConnected = false
-		logger.Error(fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server"), "timeout", "server", p.grpcClient.GetServerURL())
+		err := fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server")
+		logger.Error(err, "timeout", "server", p.grpcClient.GetServerURL())
 		return nil, err
 	}
 	if !grpcClientConnected {


### PR DESCRIPTION
Fix panic in `KedaProvider` when getting metrics from Metrics Service if the gRPC Server connection is not established.
Cherry-pick of https://github.com/kedacore/keda/pull/6010