### PR TITLE
AUTOSCALE-238: Refactor cloudevent_source test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,11 +38,6 @@ repos:
       language: system
       entry: "bash tools/sort_scalers.sh"
       files: .*scale_handler\.go$
-    - id: validate-changelog
-      name: Validate Changelog
-      language: system
-      entry: "bash hack/validate-changelog.sh"
-      pass_filenames: false
     - id: golangci-lint
       language: system
       name: Run golangci against the code

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,7 +1,7 @@
- # This dockerfile is intended to build something approximating the upstream test 
- # image, but for use in OpenShift CI. Upstream keda bumps the keda-tools image version 
- # when they feel like it, so we might just need to pay attention when we do releases. 
- FROM ghcr.io/kedacore/keda-tools:1.22.5
+ # This dockerfile is intended to build something approximating the upstream test
+ # image, but for use in OpenShift CI. Upstream keda bumps the keda-tools image version
+ # when they feel like it, so we might just need to pay attention when we do releases.
+ FROM ghcr.io/kedacore/keda-tools:1.23.8
  COPY . /src
  RUN chmod 777 -R /src
  WORKDIR /src

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -33,6 +33,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -150,6 +153,14 @@ func ExecuteCommandWithDir(cmdWithArgs, dir string) ([]byte, error) {
 }
 
 func ExecCommandOnSpecificPod(t *testing.T, podName string, namespace string, command string) (string, string, error) {
+	return executeCommandOnPod(t, podName, namespace, command, true)
+}
+
+func ExecCommandOnSpecificPodWithoutTTY(t *testing.T, podName string, namespace string, command string) (string, string, error) {
+	return executeCommandOnPod(t, podName, namespace, command, false)
+}
+
+func executeCommandOnPod(t *testing.T, podName string, namespace string, command string, tty bool) (string, string, error) {
 	cmd := []string{
 		"sh",
 		"-c",
@@ -165,7 +176,7 @@ func ExecCommandOnSpecificPod(t *testing.T, podName string, namespace string, co
 			Stdin:   false,
 			Stdout:  true,
 			Stderr:  true,
-			TTY:     true,
+			TTY:     tty,
 		}, scheme.ParameterCodec)
 	exec, err := remotecommand.NewSPDYExecutor(KubeConfig, "POST", request.URL())
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
@@ -237,7 +248,7 @@ func CreateNamespace(t *testing.T, kc *kubernetes.Clientset, nsName string) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nsName,
 			Labels: map[string]string{"type": "e2e",
-				//TODO(jkyros): I don't like this but some of the stuff we're running doesn't react well to being unprivileged right now.
+				// TODO(jkyros): I don't like this but some of the stuff we're running doesn't react well to being unprivileged right now.
 				"pod-security.kubernetes.io/enforce": "privileged",
 				"pod-security.kubernetes.io/audit":   "privileged",
 				"pod-security.kubernetes.io/warn":    "privileged",
@@ -300,7 +311,6 @@ func CreateNamespace(t *testing.T, kc *kubernetes.Clientset, nsName string) {
 		_, err := kc.RbacV1().RoleBindings(namespace.Name).Create(context.Background(), rolebinding, metav1.CreateOptions{})
 		assert.NoError(t, err, "cannot bind service accounts to SCCs")
 	}
-
 }
 
 func DeleteNamespace(t *testing.T, nsName string) {
@@ -998,4 +1008,229 @@ func CheckKubectlGetResult(t *testing.T, kind string, name string, namespace str
 
 	unqoutedOutput := strings.ReplaceAll(string(output), "\"", "")
 	assert.Equal(t, expected, unqoutedOutput)
+}
+
+// KedaConsistently checks if the provided conditionFunc consistently returns true
+// (and no error) for the entire duration specified by the context's deadline.
+// It polls the conditionFunc at the given interval.
+func KedaConsistently(ctx context.Context, conditionFunc wait.ConditionWithContextFunc, interval time.Duration) error {
+	if interval <= 0 {
+		return fmt.Errorf("polling interval must be positive, got %v", interval)
+	}
+
+	ok, err := conditionFunc(ctx)
+	if err != nil {
+		return fmt.Errorf("consistency check failed on initial check: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("consistency check failed: condition was false on initial check")
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-ticker.C:
+			ok, err := conditionFunc(ctx)
+			if err != nil {
+				return fmt.Errorf("consistency check failed during polling: %w", err)
+			}
+			if !ok {
+				return fmt.Errorf("consistency check failed: condition returned false during polling period")
+			}
+		}
+	}
+}
+
+// EventWatchResult holds the outcome of the event watch.
+type EventWatchResult struct {
+	Event corev1.Event
+	Err   error
+}
+
+// StartEventWatch starts a watch for Kubernetes events matching the specified criteria.
+// It returns a channel that will receive the first matching event or an error if the watch fails.
+func StartEventWatch(
+	ctx context.Context,
+	t *testing.T,
+	clientset *kubernetes.Clientset,
+	namespace string,
+	involvedObjectName string,
+	involvedObjectKind string,
+	expectedReason string,
+	expectedType string,
+	expectedMessages []string,
+	resourceVersion string,
+) <-chan EventWatchResult {
+	t.Helper()
+	resultChan := make(chan EventWatchResult, 1)
+
+	fieldSelectorMap := fields.Set{
+		"involvedObject.name": involvedObjectName,
+		"involvedObject.kind": involvedObjectKind,
+		"reason":              expectedReason,
+		"type":                expectedType,
+	}
+	fieldSelector := fieldSelectorMap.String()
+
+	listOptions := metav1.ListOptions{
+		FieldSelector:   fieldSelector,
+		ResourceVersion: resourceVersion,
+	}
+
+	t.Logf("Starting event watch goroutine: namespace=%s, selector='%s', messages=%v, resourceVersion=%s",
+		namespace, fieldSelector, expectedMessages, resourceVersion)
+
+	watcher, err := clientset.CoreV1().Events(namespace).Watch(ctx, listOptions)
+	assert.NoErrorf(t, err, "failed to start watch for events with selector '%s' and rv %s: %s", fieldSelector, resourceVersion, err)
+	if err != nil {
+		resultChan <- EventWatchResult{Err: err}
+		close(resultChan)
+		return resultChan
+	}
+
+	go func() {
+		defer close(resultChan)
+		defer watcher.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				err := fmt.Errorf("watch context cancelled or timed out while waiting for event: %w", ctx.Err())
+				resultChan <- EventWatchResult{Err: err}
+				return
+
+			case watchEvent, ok := <-watcher.ResultChan():
+				if !ok {
+					err := fmt.Errorf("watcher channel closed unexpectedly for selector '%s'", fieldSelector)
+					if ctx.Err() != nil {
+						err = fmt.Errorf("watcher channel closed, likely due to context timeout: %w", ctx.Err())
+					}
+					select {
+					case resultChan <- EventWatchResult{Err: err}:
+					default:
+					}
+					return
+				}
+
+				switch watchEvent.Type {
+				case watch.Added, watch.Modified:
+					event, ok := watchEvent.Object.(*corev1.Event)
+					if !ok {
+						t.Logf("Received non-Event object type (%T) from watch, skipping", watchEvent.Object)
+						continue
+					}
+
+					t.Logf("Watch goroutine received event: %s/%s - %s %s (ts: %s): %s",
+						event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Type, event.Reason,
+						event.LastTimestamp.Time.Format(time.RFC3339), event.Message)
+
+					messageMatched := false
+					for _, expectedMsg := range expectedMessages {
+						if strings.Contains(event.Message, expectedMsg) {
+							messageMatched = true
+							break
+						}
+					}
+					if !messageMatched {
+						t.Logf(" -> Skipping event: Message '%s' did not match any of expected %v", event.Message, expectedMessages)
+						continue
+					}
+
+					t.Logf("Watch goroutine found matching event: %s/%s - %s %s: %s",
+						event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Type, event.Reason, event.Message)
+					resultChan <- EventWatchResult{Event: *event}
+					return
+
+				case watch.Error:
+					status, ok := watchEvent.Object.(*metav1.Status)
+					var errMsg string
+					if ok {
+						errMsg = fmt.Sprintf("received watch.Error status: %s", status.Message)
+					} else {
+						errMsg = fmt.Sprintf("received watch.Error with unexpected object type %T: %v", watchEvent.Object, watchEvent.Object)
+					}
+					resultChan <- EventWatchResult{Err: fmt.Errorf("%s", errMsg)}
+					return
+
+				case watch.Deleted, watch.Bookmark:
+					continue
+				}
+			}
+		}
+	}()
+
+	return resultChan
+}
+
+// WatchForEventAfterTrigger starts watching for a specific Kubernetes event,
+// executes a trigger function, and then waits for the event to appear.
+func WatchForEventAfterTrigger(
+	t *testing.T,
+	kc *kubernetes.Clientset,
+	namespace string,
+	involvedObjectName string,
+	involvedObjectKind string,
+	expectedReason string,
+	expectedType string,
+	expectedMessages []string, // matches any of the messages
+	watchTimeout time.Duration,
+	triggerAction func() error,
+) {
+	t.Helper()
+
+	watchCtx, watchCancel := context.WithTimeout(context.Background(), watchTimeout)
+	defer watchCancel()
+
+	initialListOptions := metav1.ListOptions{
+		FieldSelector: fields.Set{
+			"involvedObject.name": involvedObjectName,
+			"involvedObject.kind": involvedObjectKind,
+			"reason":              expectedReason,
+			"type":                expectedType,
+		}.String(),
+		Limit: 1,
+	}
+
+	eventsList, err := kc.CoreV1().Events(namespace).List(watchCtx, initialListOptions)
+	require.NoError(t, err, "failed to get initial resource version for watch")
+
+	// Use the resource version from the initial list to start the watch
+	// This ensures we only get events that occur after the initial list
+	initialResourceVersion := eventsList.ListMeta.ResourceVersion
+
+	t.Logf("Waiting up to %s for Kubernetes event '%s' via watch...", watchTimeout, expectedReason)
+
+	resultChan := StartEventWatch(
+		watchCtx,
+		t,
+		kc,
+		namespace,
+		involvedObjectName,
+		involvedObjectKind,
+		expectedReason,
+		expectedType,
+		expectedMessages,
+		initialResourceVersion,
+	)
+
+	err = triggerAction()
+	require.NoError(t, err, "Trigger action failed")
+
+	select {
+	case result := <-resultChan:
+		assert.NoError(t, result.Err, "Event watch failed for %s", expectedReason)
+		if result.Err == nil {
+			t.Logf("Received expected Kubernetes event via watch: %s/%s - %s %s: %s",
+				result.Event.InvolvedObject.Kind, result.Event.InvolvedObject.Name, result.Event.Type, result.Event.Reason, result.Event.Message)
+		}
+
+	case <-time.After(watchTimeout + 5*time.Second):
+		assert.Fail(t, "Timed out waiting for result from Kubernetes event watch channel")
+		return
+	}
 }

--- a/tests/internals/cloudevent_source/cloudevent_source_test.go
+++ b/tests/internals/cloudevent_source/cloudevent_source_test.go
@@ -4,6 +4,7 @@
 package trigger_update_so_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -12,8 +13,12 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
+	cloudevent_types "github.com/kedacore/keda/v2/apis/eventing/v1alpha1"
+	message "github.com/kedacore/keda/v2/pkg/common/message"
+	eventreason "github.com/kedacore/keda/v2/pkg/eventreason"
 	. "github.com/kedacore/keda/v2/tests/helper"
 )
 
@@ -350,6 +355,10 @@ func TestScaledObjectGeneral(t *testing.T) {
 	// Create kubernetes resources
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
+	t.Cleanup(func() {
+		t.Log("--- cleaning up ---")
+		DeleteKubernetesResources(t, namespace, data, templates)
+	})
 	CreateKubernetesResources(t, kc, namespace, data, templates)
 
 	assert.True(t, WaitForAllPodRunningInNamespace(t, kc, namespace, 5, 20), "all pods should be running")
@@ -364,12 +373,10 @@ func TestScaledObjectGeneral(t *testing.T) {
 	testErrEventSourceExcludeValue(t, kc, data, false)
 	testErrEventSourceIncludeValue(t, kc, data, false)
 	testErrEventSourceCreation(t, kc, data, false)
-
-	DeleteKubernetesResources(t, namespace, data, templates)
 }
 
 // tests error events emitted
-func testErrEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data templateData, isClusterScope bool) {
+func testErrEventSourceEmitValue(t *testing.T, kc *kubernetes.Clientset, data templateData, isClusterScope bool) {
 	ceTemplate := ""
 	if isClusterScope {
 		ceTemplate = clusterCloudEventSourceTemplate
@@ -377,16 +384,33 @@ func testErrEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data tem
 		ceTemplate = cloudEventSourceTemplate
 	}
 
-	t.Log("--- test emitting eventsource about scaledobject err---")
+	t.Logf("--- test emitting eventsource about scaledobject err --- [isClusterScope: %t]", isClusterScope)
 	KubectlApplyWithTemplate(t, data, "cloudEventSourceTemplate", ceTemplate)
-	KubectlApplyWithTemplate(t, data, "scaledObjectErrTemplate", scaledObjectErrTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "cloudEventSourceTemplate", ceTemplate)
 
-	// wait 15 seconds to ensure event propagation
-	time.Sleep(5 * time.Second)
+	WatchForEventAfterTrigger(
+		t,
+		kc,
+		namespace,
+		scaledObjectName,
+		"ScaledObject",
+		eventreason.ScaledObjectCheckFailed,
+		corev1.EventTypeWarning,
+		[]string{message.ScaleTargetErrMsg, message.ScaleTargetNotFoundMsg},
+		60*time.Second,
+		func() error {
+			KubectlApplyWithTemplate(t, data, "scaledObjectErrTemplate", scaledObjectErrTemplate)
+			return nil
+		},
+	)
+
+	// in order to satisfy lastCloudEventTime, we cannot defer this deletion because the ExecCommand would then retrieve a stale list of current events
+	// i.e. more ScaledObjectCheckFailed events will happen between the ExecCommand and the deletion of the ScaledObject
+	// hence, we have to delete it here after an arbitrary few seconds, in order to stop all events
+	// then we will calculate lastCloudEventTime which will be updated with the ACTUAL last event without any surprises
 	KubectlDeleteWithTemplate(t, data, "scaledObjectErrTemplate", scaledObjectErrTemplate)
-	time.Sleep(10 * time.Second)
 
-	out, outErr, err := ExecCommandOnSpecificPod(t, clientName, namespace, fmt.Sprintf("curl -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectCheckFailed"))
+	out, outErr, err := ExecCommandOnSpecificPodWithoutTTY(t, clientName, namespace, fmt.Sprintf("curl -s -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectCheckFailed"))
 	assert.NotEmpty(t, out)
 	assert.Empty(t, outErr)
 	assert.NoError(t, err, "dont expect error requesting ")
@@ -404,17 +428,17 @@ func testErrEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data tem
 			foundEvents = append(foundEvents, cloudEvent)
 			data := map[string]string{}
 			err := cloudEvent.DataAs(&data)
-			t.Log("--- test emitting eventsource about scaledobject err---", "message", data["message"])
+			t.Log("--- test emitting eventsource about scaledobject err ---", "message", data["message"])
 
 			assert.NoError(t, err)
 			assert.Condition(t, func() bool {
-				if data["message"] == "ScaledObject doesn't have correct scaleTargetRef specification" || data["message"] == "Target resource doesn't exist" {
+				if data["message"] == message.ScaleTargetErrMsg || data["message"] == message.ScaleTargetNotFoundMsg {
 					return true
 				}
 				return false
 			}, "get filtered event")
 
-			assert.Equal(t, cloudEvent.Type(), "keda.scaledobject.failed.v1")
+			assert.Equal(t, cloudEvent.Type(), string(cloudevent_types.ScaledObjectFailedType))
 			assert.Equal(t, cloudEvent.Source(), expectedSource)
 			assert.Equal(t, cloudEvent.DataContentType(), "application/json")
 
@@ -423,22 +447,33 @@ func testErrEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data tem
 			}
 		}
 	}
+
 	assert.NotEmpty(t, foundEvents)
-	KubectlDeleteWithTemplate(t, data, "cloudEventSourceTemplate", ceTemplate)
-	t.Log("--- testErrEventSourceEmitValuetestErrEventSourceEmitValuer---", "cloud event time", lastCloudEventTime)
 }
 
-func testEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data templateData) {
-	t.Log("--- test emitting eventsource about scaledobject removed---")
+func testEventSourceEmitValue(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- test emitting eventsource about scaledobject removed ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	KubectlApplyWithTemplate(t, data, "deploymentTemplate", deploymentTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "deploymentTemplate", deploymentTemplate)
 
-	// wait 15 seconds to ensure event propagation
-	time.Sleep(5 * time.Second)
-	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	time.Sleep(10 * time.Second)
+	WatchForEventAfterTrigger(
+		t,
+		kc,
+		namespace,
+		scaledObjectName,
+		"ScaledObject",
+		eventreason.ScaledObjectDeleted,
+		corev1.EventTypeWarning,
+		[]string{message.ScaledObjectRemoved},
+		60*time.Second,
+		func() error {
+			KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+			return nil
+		},
+	)
 
-	out, outErr, err := ExecCommandOnSpecificPod(t, clientName, namespace, fmt.Sprintf("curl -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectDeleted"))
+	out, outErr, err := ExecCommandOnSpecificPodWithoutTTY(t, clientName, namespace, fmt.Sprintf("curl -s -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectDeleted"))
 	assert.NotEmpty(t, out)
 	assert.Empty(t, outErr)
 	assert.NoError(t, err, "dont expect error requesting ")
@@ -458,8 +493,8 @@ func testEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data templa
 			err := cloudEvent.DataAs(&data)
 
 			assert.NoError(t, err)
-			assert.Equal(t, data["message"], "ScaledObject was deleted")
-			assert.Equal(t, cloudEvent.Type(), "keda.scaledobject.removed.v1")
+			assert.Equal(t, data["message"], message.ScaledObjectRemoved)
+			assert.Equal(t, cloudEvent.Type(), string(cloudevent_types.ScaledObjectRemovedType))
 			assert.Equal(t, cloudEvent.Source(), expectedSource)
 			assert.Equal(t, cloudEvent.DataContentType(), "application/json")
 
@@ -468,12 +503,13 @@ func testEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data templa
 			}
 		}
 	}
+
 	assert.NotEmpty(t, foundEvents)
 }
 
 // tests error events not emitted by
 func testErrEventSourceExcludeValue(t *testing.T, _ *kubernetes.Clientset, data templateData, isClusterScope bool) {
-	t.Log("--- test emitting eventsource about scaledobject err with exclude filter---", "cloud event time", lastCloudEventTime)
+	t.Logf("--- test emitting eventsource about scaledobject err with exclude filter --- [isClusterScope: %t]", isClusterScope)
 
 	ceTemplate := ""
 	if isClusterScope {
@@ -483,40 +519,56 @@ func testErrEventSourceExcludeValue(t *testing.T, _ *kubernetes.Clientset, data 
 	}
 
 	KubectlApplyWithTemplate(t, data, "cloudEventSourceWithExcludeTemplate", ceTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "cloudEventSourceWithExcludeTemplate", ceTemplate)
 	KubectlApplyWithTemplate(t, data, "scaledObjectErrTemplate", scaledObjectErrTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "scaledObjectErrTemplate", scaledObjectErrTemplate)
 
-	// wait 15 seconds to ensure event propagation
-	// TODO(maxcao13): test is flaking, but only on OpenShift
-	// bump the timings up so that this happens less, refactor later
-	time.Sleep(60 * time.Second)
+	consistencyDuration := 30 * time.Second
+	pollingInterval := 5 * time.Second
 
-	out, outErr, err := ExecCommandOnSpecificPod(t, clientName, namespace, fmt.Sprintf("curl -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectCheckFailed"))
-	assert.NotEmpty(t, out)
-	assert.Empty(t, outErr)
-	assert.NoError(t, err, "dont expect error requesting ")
+	t.Logf("Checking consistently every %v for %v that the excluded CloudEvent does not get emitted", pollingInterval, consistencyDuration)
+	conditionFunc := func(ctx context.Context) (bool, error) {
+		out, outErr, err := ExecCommandOnSpecificPodWithoutTTY(t, clientName, namespace, fmt.Sprintf("curl -s -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectCheckFailed"))
 
-	cloudEvents := []cloudevents.Event{}
-	err = json.Unmarshal([]byte(out), &cloudEvents)
+		if err != nil {
+			return false, fmt.Errorf("command execution error: %w (stderr: %s)", err, outErr)
+		}
+		if outErr != "" {
+			return false, fmt.Errorf("command execution error: %s", outErr)
+		}
+		if out == "" {
+			return false, fmt.Errorf("command execution returned empty output")
+		}
 
-	assert.NoError(t, err, "dont expect error unmarshaling the cloudEvents")
+		var cloudEvents []cloudevents.Event
+		err = json.Unmarshal([]byte(out), &cloudEvents)
+		if err != nil {
+			return false, fmt.Errorf("cannot unmarshal cloudevents JSON '%s': %w", out, err)
+		}
 
-	for _, cloudEvent := range cloudEvents {
-		assert.Condition(t, func() bool {
+		for _, cloudEvent := range cloudEvents {
 			if cloudEvent.Subject() == expectedSubject &&
-				cloudEvent.Time().After(lastCloudEventTime) &&
-				cloudEvent.Type() == "keda.scaledobject.failed.v1" {
-				return false
+				cloudEvent.Type() == string(cloudevent_types.ScaledObjectFailedType) &&
+				cloudEvent.Time().After(lastCloudEventTime) {
+				t.Logf("found excluded event: subject=%q, type=%q, time=%s, lastCloudEventTime=%s", cloudEvent.Subject(), cloudEvent.Type(), cloudEvent.Time().Format(time.RFC3339), lastCloudEventTime.Format(time.RFC3339))
+				return false, nil
 			}
-			return true
-		}, "get filtered event")
+		}
+
+		t.Log("no excluded event found... continuing to validate consistency")
+		return true, nil
 	}
 
-	KubectlDeleteWithTemplate(t, data, "cloudEventSourceWithExcludeTemplate", ceTemplate)
+	ctx, cancel := context.WithTimeout(context.Background(), consistencyDuration)
+	defer cancel()
+
+	err := KedaConsistently(ctx, conditionFunc, pollingInterval)
+	assert.NoError(t, err, "KedaConsistently check failed: An excluded event was likely found, or a check error occurred.")
 }
 
 // tests error events in include filter
-func testErrEventSourceIncludeValue(t *testing.T, _ *kubernetes.Clientset, data templateData, isClusterScope bool) {
-	t.Log("--- test emitting eventsource about scaledobject err with include filter---")
+func testErrEventSourceIncludeValue(t *testing.T, kc *kubernetes.Clientset, data templateData, isClusterScope bool) {
+	t.Logf("--- test emitting eventsource about scaledobject err with include filter --- [isClusterScope: %t]", isClusterScope)
 
 	ceTemplate := ""
 	if isClusterScope {
@@ -524,40 +576,50 @@ func testErrEventSourceIncludeValue(t *testing.T, _ *kubernetes.Clientset, data 
 	} else {
 		ceTemplate = cloudEventSourceWithIncludeTemplate
 	}
-
 	KubectlApplyWithTemplate(t, data, "cloudEventSourceWithIncludeTemplate", ceTemplate)
-	KubectlApplyWithTemplate(t, data, "scaledObjectErrTemplate", scaledObjectErrTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "cloudEventSourceWithIncludeTemplate", ceTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "scaledObjectErrTemplate", scaledObjectErrTemplate)
 
-	// wait 15 seconds to ensure event propagation
-	// TODO(maxcao13): test is flaking, but only on OpenShift
-	// bump the timings up so that this happens less, refactor later
-	time.Sleep(60 * time.Second)
+	WatchForEventAfterTrigger(
+		t,
+		kc,
+		namespace,
+		scaledObjectName,
+		"ScaledObject",
+		eventreason.ScaledObjectCheckFailed,
+		corev1.EventTypeWarning,
+		[]string{message.ScaleTargetErrMsg, message.ScaleTargetNotFoundMsg},
+		60*time.Second,
+		func() error {
+			KubectlApplyWithTemplate(t, data, "scaledObjectErrTemplate", scaledObjectErrTemplate)
+			return nil
+		},
+	)
 
-	out, outErr, err := ExecCommandOnSpecificPod(t, clientName, namespace, fmt.Sprintf("curl -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectCheckFailed"))
+	out, outErr, err := ExecCommandOnSpecificPodWithoutTTY(t, clientName, namespace, fmt.Sprintf("curl -s -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectCheckFailed"))
 	assert.NotEmpty(t, out)
 	assert.Empty(t, outErr)
 	assert.NoError(t, err, "dont expect error requesting ")
 
 	cloudEvents := []cloudevents.Event{}
 	err = json.Unmarshal([]byte(out), &cloudEvents)
-
 	assert.NoError(t, err, "dont expect error unmarshaling the cloudEvents")
 
-	foundEvents := []cloudevents.Event{}
+	foundCloudEvents := []cloudevents.Event{}
 	for _, cloudEvent := range cloudEvents {
 		if cloudEvent.Subject() == expectedSubject &&
 			cloudEvent.Time().After(lastCloudEventTime) &&
-			cloudEvent.Type() == "keda.scaledobject.failed.v1" {
-			foundEvents = append(foundEvents, cloudEvent)
+			cloudEvent.Type() == string(cloudevent_types.ScaledObjectFailedType) {
+			foundCloudEvents = append(foundCloudEvents, cloudEvent)
 		}
 	}
-	assert.NotEmpty(t, foundEvents)
-	KubectlDeleteWithTemplate(t, data, "cloudEventSourceWithIncludeTemplate", ceTemplate)
+
+	assert.NotEmpty(t, foundCloudEvents)
 }
 
 // tests error event type when creation
 func testErrEventSourceCreation(t *testing.T, _ *kubernetes.Clientset, data templateData, isClusterScope bool) {
-	t.Log("--- test emitting eventsource about scaledobject err with include filter---")
+	t.Logf("--- test emitting eventsource about scaledobject err with include filter --- [isClusterScope: %t]", isClusterScope)
 
 	ceErrTemplate := ""
 	ceErrTemplate2 := ""
@@ -568,8 +630,6 @@ func testErrEventSourceCreation(t *testing.T, _ *kubernetes.Clientset, data temp
 		ceErrTemplate = cloudEventSourceWithErrTypeTemplate
 		ceErrTemplate2 = cloudEventSourceWithErrTypeTemplate2
 	}
-
-	// KubectlDeleteWithTemplate(t, data, "cloudEventSourceTemplate", cloudEventSourceTemplate)
 
 	err := KubectlApplyWithErrors(t, data, "cloudEventSourceWithErrTypeTemplate", ceErrTemplate)
 	if isClusterScope {

--- a/tests/scalers/kafka/kafka_test.go
+++ b/tests/scalers/kafka/kafka_test.go
@@ -669,9 +669,9 @@ func testPersistentLag(t *testing.T, kc *kubernetes.Clientset, data templateData
 	// Scale application with kafka messages in persistentLagTopic
 	publishMessage(t, persistentLagTopic)
 	// TODO(jkyros): this test started flaking after the offset tests were added, but only on OpenShift. It's not
-	// actually broken. From what I can tell, the published message gets snarfed off the queue almost immediatly and we miss it here
+	// actually broken. From what I can tell, the published message gets snarfed off the queue almost immediately and we miss it here
 	// if our polling interval is 2s (the upstream setting), but we always catch it if it's 1s.
-	// Previously this persistent lag test ran immediatly after testMultiTopic, and at the end of that test the deployment count was 2,
+	// Previously this persistent lag test ran immediately after testMultiTopic, and at the end of that test the deployment count was 2,
 	// but now with the offset tests, the deployment starts at 0 and scales up, so somehow maybe we had either been passing this assertion
 	// with the deployment from the previous case, or kafka was left in a different state with the old test than it does with the current test.
 	// I'd love to refactor this to be more deterministic, but it will take time. For now, we set the polling interval to 1s and vow to come back


### PR DESCRIPTION
This PR refactors the `cloudevent_source_test.go` file to rely on events instead of sleeping in order to progress and also betters the cleanup between and after tests.

Also does some cleanup including
* ignoring the validate changelog precommit config downstream
* running golangci-lint and fixing our carry patches
* bump the `Dockerfile.tests` version because I missed that in the upstream rebase

WIP for now. Checking if this actually solves flakes on our CI since it's hard to tell on local machines.

Eventually, I want to propose the test fix commit to upstream so we can drop the commit here in the next rebase.