### PR TITLE
AUTOSCALE-71: CMA e2e launcher for downstream/OpenShift

### DIFF
--- a/openshift-e2e.yaml
+++ b/openshift-e2e.yaml
@@ -1,0 +1,23 @@
+keda:
+  skipSetup: true
+  skipCleanup: true
+testCategories:
+  internals:
+    mode: exclude
+    tests:
+      - eventemitter/azureeventgridtopic
+      - global_custom_ca
+  scalers:
+    mode: include
+    tests:
+      - cpu
+      - cron
+      - kafka
+      - memory
+      - prometheus
+  secret-providers:
+    mode: exclude
+  sequential:
+    mode: exclude
+    tests:
+      - datadog_dca

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,114 @@ go test -v -tags e2e ./scalers/azure/azure_queue/azure_queue_test.go # Assumes t
 
 Refer to [this](https://pkg.go.dev/testing) for more information about testing in `Go`.
 
+### Running e2e tests with a custom config file
+
+The `E2E_TEST_CONFIG` environment variable can be used to run a subset of tests with a custom config file.
+It can also be used to configure test setup. For example, to run tests without deploying KEDA, or to deploy KEDA using custom images.
+
+```bash
+E2E_TEST_CONFIG=tests/example-config.yaml go test -v -tags e2e ./tests/run-all.go
+```
+
+Supplying environment variables directly will override any relevant config file field.
+
+Examples:
+
+- `E2E_TEST_REGEX` will override the `testCategories` field in the config file.
+- `E2E_INSTALL_KEDA=false` will run the tests without deploying KEDA, even if the config file has `keda.install: true`.
+
+#### Filtering tests
+
+The config file is a YAML file which can be used to configure the test setup and the test categories and the test suites to run.
+You can include or exclude suites in a category, or exclude an entire category.
+The current categories that exist are defined in the `tests/` subdirectory:
+
+- `internals`
+- `scalers`
+- `secret-providers`
+- `sequential`
+
+Here is an example config that will run all tests in the `scalers` category, but `exclude` the tests in the `cpu` suite.
+It will also `exclude` all tests in the `internals` category.
+Omitting an existing category in the config file will run all tests in that category.
+
+```yaml
+testCategories:
+  # This will run all tests in the scalers category, but exclude the cpu test.
+  scalers:
+    mode: exclude
+    tests:
+      - cpu
+  # Using mode: exclude and omitting the tests list will exclude all tests in the category.
+  internals:
+    mode: exclude
+  secret-providers:
+    mode: exclude
+  sequential:
+    mode: exclude
+```
+
+You can also do the opposite, and `include` tests, but `exclude` the rest:
+
+```yaml
+testCategories:
+  # This will only run the aws_cloudwatch, cpu, and kafka scaler tests, and exclude the rest.
+  scalers:
+    mode: include
+    tests:
+      - aws/aws_cloudwatch # you can also specify a deeper nested test by it's "directory path"
+      - cpu
+      - kafka
+  # Since the other categories are not specified, all tests in those categories will not be run.
+```
+
+A valid config file must have the `testCategories` field, and all defined categories must have a `mode` field which is either `include` or `exclude`.
+
+This is an example of a valid config file with the `testCategories` field set to an empty map. This will run all tests in all categories.
+
+```yaml
+# This will run all tests in all categories.
+testCategories: {}
+```
+
+This example is invalid, and will fail and emit an error message:
+
+```yaml
+testCategories:
+# Error loading test config: testCategories is a required field. Did you mean to set this to an empty map?
+```
+
+You can specify a custom go regex directly through the `E2E_TEST_REGEX` environment variable. This will override the config file environment variable.
+
+Not specifying either `E2E_TEST_CONFIG` or `E2E_TEST_REGEX` will run all tests in all categories.
+
+You can also check what tests would be executed and other configurations without actually running them by setting the `dryRun` field to `true`.
+
+e.g.,
+
+```yaml
+dryRun: true
+keda:
+  # ...omitted
+testCategories:
+  # ...omitted
+```
+
+#### Customizing test setup
+
+The config file can also be used to customize the test setup. For example, to deploy KEDA using custom images.
+
+```yaml
+keda:
+  # These are the default values.
+  skipSetup: false # If true, the test script will skip the setup phase.
+  skipCleanup: false # If true, the test script will skip the cleanup phase.
+  imageRegistry: ""
+  imageRepo: ""
+```
+
+Note that if `imageRegistry` and `imageRepo` are empty, the test script will use the default KEDA repository and registry defined in the `Makefile`.
+
 ## E2E Test Setup
 
 The test script will run in 3 phases:

--- a/tests/example-config.yml
+++ b/tests/example-config.yml
@@ -1,0 +1,15 @@
+# This is an example test config file to be used with the run-all.go file.
+dryRun: false # set to true to see what tests would run without executing them
+keda:
+  skipSetup: false # set to true to skip the setup entirely (including e.g., setup keda, helm, workload identity, etc.)
+  skipCleanup: false # set to true to skip the cleanup entirely (cleaning up everything in setup)
+  imageRegistry: "" # use KEDA images from registry
+  imageRepo: "" # use KEDA images from repo
+# The e2e launcher will only run the cpu scaler test.
+testCategories:
+  internals:
+    mode: exclude
+  scalers:
+    mode: include
+    tests:
+      - cpu

--- a/tests/helper/config.go
+++ b/tests/helper/config.go
@@ -1,0 +1,101 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var KEDATestConfig = TestConfig{
+	KEDA: &KEDAConfig{
+		SkipSetup:     false,
+		SkipCleanup:   false,
+		ImageRegistry: "", // default to Makefile settings
+		ImageRepo:     "", // default to Makefile settings
+	},
+	TestCategories: map[string]TestCategory{},
+	DryRun:         false,
+}
+
+type TestConfig struct {
+	KEDA           *KEDAConfig             `yaml:"keda"`
+	TestCategories map[string]TestCategory `yaml:"testCategories"`
+	DryRun         bool                    `yaml:"dryRun,omitempty"`
+}
+
+type KEDAConfig struct {
+	SkipSetup     bool   `yaml:"skipSetup"`
+	SkipCleanup   bool   `yaml:"skipCleanup"`
+	ImageRegistry string `yaml:"imageRegistry"`
+	ImageRepo     string `yaml:"imageRepo"`
+}
+
+func (tc *TestConfig) GetAllCategories() []string {
+	return []string{"internals", "scalers", "secret-providers", "sequential"}
+}
+
+// Validate enforces that all categories have a mode, and that the mode is either include or exclude.
+func (tc *TestConfig) Validate() error {
+	// validate that testCategories exists
+	if tc.TestCategories == nil {
+		return fmt.Errorf("testCategories is a required field. Did you mean to set this to an empty map?")
+	}
+
+	// validate that all categories have a mode, and that the mode is either include or exclude
+	for name, cat := range tc.TestCategories {
+		if cat.Mode == "" {
+			return fmt.Errorf("category %q: mode is a required field", name)
+		}
+		switch cat.Mode {
+		case TestCategoryModeInclude, TestCategoryModeExclude:
+		default:
+			return fmt.Errorf("category %q: invalid mode %q", name, cat.Mode)
+		}
+		for i, test := range cat.Tests {
+			// check if there's trailing slashes in the path, if so, don't throw an error, just remove them
+			if strings.HasSuffix(test, string(os.PathSeparator)) {
+				cat.Tests[i] = strings.TrimSuffix(test, string(os.PathSeparator))
+			}
+		}
+	}
+	return nil
+}
+
+type TestCategory struct {
+	Mode  TestCategoryMode `yaml:"mode"`
+	Tests []string         `yaml:"tests,omitempty"`
+}
+
+type TestCategoryMode string
+
+const (
+	TestCategoryModeInclude TestCategoryMode = "include"
+	TestCategoryModeExclude TestCategoryMode = "exclude"
+)
+
+// LoadTestConfig builds a TestConfig and sets the global helper.TestConfig variable.
+// If the env var is not set, then it is initialized to a default config.
+func LoadTestConfig() error {
+	configPath := os.Getenv("E2E_TEST_CONFIG")
+	if configPath == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	var config TestConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return err
+	}
+	if err := config.Validate(); err != nil {
+		return err
+	}
+
+	KEDATestConfig = config
+	return nil
+}

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -68,6 +68,11 @@ const (
 )
 
 const (
+	WaitShort     = 20 * time.Second
+	IntervalShort = 1 * time.Second
+)
+
+const (
 	caCrtPath = "/tmp/keda-e2e-ca.crt"
 	caKeyPath = "/tmp/keda-e2e-ca.key"
 )
@@ -1025,6 +1030,42 @@ func CheckKubectlGetResult(t *testing.T, kind string, name string, namespace str
 
 	unqoutedOutput := strings.ReplaceAll(string(output), "\"", "")
 	assert.Equal(t, expected, unqoutedOutput)
+}
+
+// KedaEventually checks if the provided conditionFunc eventually returns true
+// (and no error) within the context's deadline. It polls the conditionFunc
+// at the given interval until the condition is met or the context times out.
+func KedaEventually(ctx context.Context, conditionFunc wait.ConditionWithContextFunc, interval time.Duration) error {
+	if interval <= 0 {
+		return fmt.Errorf("polling interval must be positive, got %v", interval)
+	}
+
+	ok, err := conditionFunc(ctx)
+	if err != nil {
+		return fmt.Errorf("eventually check failed on initial check: %w", err)
+	}
+	if ok {
+		return nil
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("eventually check failed: context deadline exceeded before condition was met")
+
+		case <-ticker.C:
+			ok, err := conditionFunc(ctx)
+			if err != nil {
+				return fmt.Errorf("eventually check failed during polling: %w", err)
+			}
+			if ok {
+				return nil
+			}
+		}
+	}
 }
 
 // KedaConsistently checks if the provided conditionFunc consistently returns true

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -90,6 +90,13 @@ var (
 	InstallKafka                  = os.Getenv("E2E_INSTALL_KAFKA")
 )
 
+func init() {
+	if err := LoadTestConfig(); err != nil {
+		fmt.Printf("Error loading test config: %v\n", err)
+		os.Exit(1)
+	}
+}
+
 var (
 	KubeClient     *kubernetes.Clientset
 	KedaKubeClient *v1alpha1.KedaV1alpha1Client
@@ -141,10 +148,20 @@ func ExecuteCommand(cmdWithArgs string) ([]byte, error) {
 }
 
 func ExecuteCommandWithDir(cmdWithArgs, dir string) ([]byte, error) {
-	out, err := ParseCommandWithDir(cmdWithArgs, dir).Output()
+	return ExecuteCommandWithDirAndEnv(cmdWithArgs, dir, nil)
+}
+
+func ExecuteCommandWithDirAndEnv(cmdWithArgs, dir string, env map[string]string) ([]byte, error) {
+	cmd := ParseCommandWithDir(cmdWithArgs, dir)
+
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	out, err := cmd.Output()
 	if err != nil {
-		exitError, ok := err.(*exec.ExitError)
-		if ok {
+		if exitError, ok := err.(*exec.ExitError); ok {
 			return out, ExecutionError{StdError: exitError.Stderr}
 		}
 	}

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
-	"time"
 
 	prommodel "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -487,7 +486,7 @@ func getTemplateData() (templateData, []Template) {
 }
 
 func fetchAndParsePrometheusMetrics(t *testing.T, cmd string) map[string]*prommodel.MetricFamily {
-	out, _, err := ExecCommandOnSpecificPod(t, clientName, testNamespace, cmd)
+	out, _, err := ExecCommandOnSpecificPodWithoutTTY(t, clientName, testNamespace, cmd)
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 
 	parser := expfmt.TextParser{}
@@ -497,6 +496,33 @@ func fetchAndParsePrometheusMetrics(t *testing.T, cmd string) map[string]*prommo
 	assert.NoErrorf(t, err, "cannot parse metrics - %s", err)
 
 	return families
+}
+
+// WaitForPrometheusMetric waits for a specific metric to appear in the Prometheus metrics endpoint
+// and validates that the MetricFamily it has certain conditions using the provided familyValidator function.
+// Returns the parsed MetricFamily.
+func WaitForPrometheusMetric(t *testing.T, metricToWaitFor string, familyValidator func(family *prommodel.MetricFamily) bool) map[string]*prommodel.MetricFamily {
+	contextWithTimeout, cancel := context.WithTimeout(context.Background(), WaitShort)
+	defer cancel()
+	var family map[string]*prommodel.MetricFamily
+	err := KedaEventually(contextWithTimeout, func(ctx context.Context) (bool, error) {
+		t.Logf("Waiting for metric %s", metricToWaitFor)
+		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+
+		if _, ok := family[metricToWaitFor]; ok {
+			if familyValidator(family[metricToWaitFor]) {
+				return true, nil
+			}
+			return false, nil
+		}
+		return false, nil
+	}, IntervalShort)
+
+	if err != nil {
+		t.Errorf("error waiting for metric %s: %v", metricToWaitFor, err)
+	}
+
+	return family
 }
 
 func testScalerMetricValue(t *testing.T) {
@@ -529,33 +555,24 @@ func testScaledObjectErrors(t *testing.T, data templateData) {
 	t.Log("--- testing scaled object errors ---")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
 
-	// wait for 2 seconds as pollinginterval is 2
-	time.Sleep(20 * time.Second)
+	WaitForPrometheusMetric(t, "keda_scaled_object_errors_total", func(family *prommodel.MetricFamily) bool {
+		errCounterVal1 := getErrorMetricsValue(family)
 
-	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
-	val, ok := family["keda_scaled_object_errors_total"]
-	assert.True(t, ok, "keda_scaled_object_errors_total not available")
-	if ok {
-		errCounterVal1 := getErrorMetricsValue(val)
+		// in the nested wait, we are just waiting for errCounterVal2 to eventually be greater that the first errCounterVal1
+		metrics2 := WaitForPrometheusMetric(t, "keda_scaled_object_errors_total", func(family *prommodel.MetricFamily) bool {
+			errCounterVal2 := getErrorMetricsValue(family)
+			return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
+		})
 
-		// wait for 2 seconds as pollinginterval is 2
-		time.Sleep(2 * time.Second)
+		errCounterVal2 := getErrorMetricsValue(metrics2["keda_scaled_object_errors_total"])
 
-		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
-		val, ok := family["keda_scaled_object_errors_total"]
-		assert.True(t, ok, "keda_scaled_object_errors_total not available")
-		if ok {
-			errCounterVal2 := getErrorMetricsValue(val)
-			assert.NotEqual(t, errCounterVal2, float64(0))
-			assert.GreaterOrEqual(t, errCounterVal2, errCounterVal1)
-		}
-	}
+		// we don't have to check again, but extra validation is fine
+		return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
+	})
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
-	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 }
 
@@ -563,37 +580,24 @@ func testScaledJobErrors(t *testing.T, data templateData) {
 	t.Log("--- testing scaled job errors ---")
 
 	KubectlDeleteWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
-	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "wrongScaledJobTemplate", wrongScaledJobTemplate)
 
-	// wait for 2 seconds as pollinginterval is 2
-	time.Sleep(20 * time.Second)
+	WaitForPrometheusMetric(t, "keda_scaled_job_errors_total", func(family *prommodel.MetricFamily) bool {
+		errCounterVal1 := getErrorMetricsValue(family)
 
-	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
-	val, ok := family["keda_scaled_job_errors_total"]
-	assert.True(t, ok, "keda_scaled_job_errors_total not available")
-	if ok {
-		errCounterVal1 := getErrorMetricsValue(val)
+		// in the nested wait, we are just waiting for errCounterVal2 to eventually be greater that the first errCounterVal1
+		metrics2 := WaitForPrometheusMetric(t, "keda_scaled_job_errors_total", func(family *prommodel.MetricFamily) bool {
+			errCounterVal2 := getErrorMetricsValue(family)
+			return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
+		})
 
-		// wait for 2 seconds as pollinginterval is 2
-		time.Sleep(2 * time.Second)
+		errCounterVal2 := getErrorMetricsValue(metrics2["keda_scaled_job_errors_total"])
 
-		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
-		val, ok := family["keda_scaled_job_errors_total"]
-		assert.True(t, ok, "keda_scaled_job_errors_total not available")
-		if ok {
-			errCounterVal2 := getErrorMetricsValue(val)
-			assert.NotEqual(t, errCounterVal2, float64(0))
-			assert.GreaterOrEqual(t, errCounterVal2, errCounterVal1)
-		} else {
-			t.Errorf("metric keda_scaled_job_errors_total not available")
-		}
-	} else {
-		t.Errorf("metric keda_scaled_job_errors_total not available")
-	}
+		// we don't have to check again, but extra validation is fine
+		return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
+	})
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledJobTemplate", wrongScaledJobTemplate)
-	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
 }
 
@@ -601,38 +605,28 @@ func testScalerErrors(t *testing.T, data templateData) {
 	t.Log("--- testing scaler errors ---")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
-
 	KubectlDeleteWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
-	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "wrongScaledJobTemplate", wrongScaledJobTemplate)
 
-	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
-	val, ok := family["keda_scaler_detail_errors_total"]
-	assert.True(t, ok, "keda_scaler_detail_errors_total not available")
-	if ok {
-		errCounterVal1 := getErrorMetricsValue(val)
+	WaitForPrometheusMetric(t, "keda_scaler_detail_errors_total", func(family *prommodel.MetricFamily) bool {
+		errCounterVal1 := getErrorMetricsValue(family)
 
-		// wait for 20 seconds to correctly fetch metrics.
-		time.Sleep(20 * time.Second)
+		// in the nested wait, we are just waiting for errCounterVal2 to eventually be greater that the first errCounterVal1
+		metrics2 := WaitForPrometheusMetric(t, "keda_scaler_detail_errors_total", func(family *prommodel.MetricFamily) bool {
+			errCounterVal2 := getErrorMetricsValue(family)
+			return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
+		})
 
-		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
-		val, ok := family["keda_scaler_detail_errors_total"]
-		assert.True(t, ok, "keda_scaler_detail_errors_total not available")
-		if ok {
-			errCounterVal2 := getErrorMetricsValue(val)
-			assert.NotEqual(t, errCounterVal2, float64(0))
-			assert.GreaterOrEqual(t, errCounterVal2, errCounterVal1)
-		}
-	}
+		errCounterVal2 := getErrorMetricsValue(metrics2["keda_scaler_detail_errors_total"])
+
+		// we don't have to check again, but extra validation is fine
+		return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
+	})
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledJobTemplate", wrongScaledJobTemplate)
-	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
-
 	KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
-	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 }
 
@@ -828,18 +822,41 @@ func testScaledObjectPausedMetric(t *testing.T, data templateData) {
 
 	// Pause the ScaledObject
 	KubectlApplyWithTemplate(t, data, "scaledObjectPausedTemplate", scaledObjectPausedTemplate)
-	time.Sleep(20 * time.Second)
 
 	// Check that the paused metric is now true
-	families := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+	families := WaitForPrometheusMetric(t, "keda_scaled_object_paused", func(family *prommodel.MetricFamily) bool {
+		metricValue := 0.0
+		metrics := family.GetMetric()
+		for _, metric := range metrics {
+			labels := metric.GetLabel()
+			for _, label := range labels {
+				if *label.Name == labelScaledObject && *label.Value == scaledObjectName {
+					metricValue = *metric.Gauge.Value
+				}
+			}
+		}
+
+		return metricValue == float64(1)
+	})
 	assertScaledObjectPausedMetric(t, families, scaledObjectName, true)
 
 	// Unpause the ScaledObject
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	time.Sleep(20 * time.Second)
 
 	// Check that the paused metric is back to false
-	families = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+	families = WaitForPrometheusMetric(t, "keda_scaled_object_paused", func(family *prommodel.MetricFamily) bool {
+		metricValue := 0.0
+		metrics := family.GetMetric()
+		for _, metric := range metrics {
+			labels := metric.GetLabel()
+			for _, label := range labels {
+				if *label.Name == labelScaledObject && *label.Value == scaledObjectName {
+					metricValue = *metric.Gauge.Value
+				}
+			}
+		}
+		return metricValue == float64(0)
+	})
 	assertScaledObjectPausedMetric(t, families, scaledObjectName, false)
 }
 
@@ -1358,62 +1375,63 @@ func testCloudEventEmitted(t *testing.T, data templateData) {
 	t.Log("--- testing cloudevent emitted ---")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+
 	KubectlApplyWithTemplate(t, data, "cloudEventSourceTemplate", cloudEventSourceTemplate)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
-	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+	defer KubectlDeleteWithTemplate(t, data, "cloudEventSourceTemplate", cloudEventSourceTemplate)
 
-	if val, ok := family["keda_cloudeventsource_events_emitted_total"]; ok {
-		var found bool
-		metrics := val.GetMetric()
-		for _, metric := range metrics {
+	familyValidator := func(family *prommodel.MetricFamily) bool {
+		labels := family.GetMetric()
+		found := false
+		for _, metric := range labels {
 			labels := metric.GetLabel()
 			if len(labels) >= 4 &&
 				*labels[0].Value == "prometheus-metrics-test-ce" &&
 				*labels[1].Value == "http" &&
 				*labels[2].Value == "prometheus-metrics-test-ns" &&
-				*labels[3].Value == "emitted" {
-				assert.GreaterOrEqual(t, *metric.Counter.Value, float64(1))
+				*labels[3].Value == "emitted" &&
+				metric.GetCounter().GetValue() >= 1 {
 				found = true
 			}
 		}
-		assert.Equal(t, true, found)
-	} else {
-		t.Errorf("metric not available")
+		return found
 	}
+
+	families := WaitForPrometheusMetric(t, "keda_cloudeventsource_events_emitted_total", familyValidator)
+	metric := families["keda_cloudeventsource_events_emitted_total"]
+
+	assert.True(t, familyValidator(metric))
 }
 
 func testCloudEventEmittedError(t *testing.T, data templateData) {
 	t.Log("--- testing cloudevent emitted error ---")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	KubectlDeleteWithTemplate(t, data, "cloudEventSourceTemplate", cloudEventSourceTemplate)
+
 	KubectlApplyWithTemplate(t, data, "wrongCloudEventSourceTemplate", wrongCloudEventSourceTemplate)
-	time.Sleep(1 * time.Second)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	time.Sleep(5 * time.Second)
 
-	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+	defer KubectlDeleteWithTemplate(t, data, "wrongCloudEventSourceTemplate", wrongCloudEventSourceTemplate)
 
-	if val, ok := family["keda_cloudeventsource_events_emitted_total"]; ok {
-		var found bool
-		metrics := val.GetMetric()
-		for _, metric := range metrics {
+	familyValidator := func(family *prommodel.MetricFamily) bool {
+		labels := family.GetMetric()
+		for _, metric := range labels {
 			labels := metric.GetLabel()
 			if len(labels) >= 4 &&
 				*labels[0].Value == "prometheus-metrics-test-ce-w" &&
 				*labels[1].Value == "http" &&
 				*labels[2].Value == "prometheus-metrics-test-ns" &&
-				*labels[3].Value == "failed" {
-				assert.GreaterOrEqual(t, *metric.Counter.Value, float64(5))
-				found = true
+				*labels[3].Value == "failed" &&
+				metric.GetCounter().GetValue() >= 5 {
+				return true
 			}
 		}
-		assert.Equal(t, true, found)
-	} else {
-		t.Errorf("metric not available")
+		return false
 	}
 
-	KubectlDeleteWithTemplate(t, data, "wrongCloudEventSourceTemplate", wrongCloudEventSourceTemplate)
-	KubectlApplyWithTemplate(t, data, "cloudEventSourceTemplate", cloudEventSourceTemplate)
+	families := WaitForPrometheusMetric(t, "keda_cloudeventsource_events_emitted_total", familyValidator)
+	metric := families["keda_cloudeventsource_events_emitted_total"]
+
+	assert.True(t, familyValidator(metric))
 }

--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -225,7 +225,17 @@ func TestDeployKEDA(t *testing.T) {
 	_, err := KubeClient.CoreV1().Secrets(KEDANamespace).Create(context.Background(), secret, v1.CreateOptions{})
 	require.NoErrorf(t, err, "error deploying custom CA - %s", err)
 
-	out, err := ExecuteCommandWithDir("make deploy", "../..")
+	envVars := make(map[string]string)
+	if KEDATestConfig.KEDA.ImageRegistry != "" {
+		envVars["IMAGE_REGISTRY"] = KEDATestConfig.KEDA.ImageRegistry
+	}
+	if KEDATestConfig.KEDA.ImageRepo != "" {
+		envVars["IMAGE_REPO"] = KEDATestConfig.KEDA.ImageRepo
+	}
+
+	// We shouldn't duplicate the defaults that exist in the Makefile.
+	// If the config file fields are not set, don't override. The Makefile will use default values.
+	out, err := ExecuteCommandWithDirAndEnv("make deploy", "../..", envVars)
 	require.NoErrorf(t, err, "error deploying KEDA - %s", err)
 
 	t.Log(string(out))


### PR DESCRIPTION
Cherry-pick of upstream 7000 and also adds a commit to create a canonical config file where we can enable/disable e2e tests without hacking it in the Makefile.

Rather than using our own e2e launcher, we use the upstream one but we use our own custom e2e config file that allows us to enable/disable tests as we wish. In the future, when we enable features, or need to disable tests that don't work and also do not support anyways, we can do it all from this file.