### PR TITLE
AUTOSCALE-459: Downstream log deprecation warning for old adapter log args

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -272,6 +272,17 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zapOpts...))
 
+	// Warn about deprecated logging flags
+	if cmd.Flags().Changed("v") {
+		setupLog.Info("DEPRECATION WARNING: The '-v' flag is deprecated and will be removed in a future release. Please use '--zap-log-level' instead (e.g., '--zap-log-level=-1' for info, '--zap-log-level=-2' for debug)")
+	}
+	if cmd.Flags().Changed("logtostderr") {
+		setupLog.Info("DEPRECATION WARNING: The '--logtostderr' flag is deprecated and will be removed in a future release. Please use '--zap-encoder=console' instead")
+	}
+	if cmd.Flags().Changed("stderrthreshold") {
+		setupLog.Info("DEPRECATION WARNING: The '--stderrthreshold' flag is deprecated and has no equivalent in the new logging system. This flag is a no-op and will be removed in a future release")
+	}
+
 	err = printWelcomeMsg(cmd)
 	if err != nil {
 		return


### PR DESCRIPTION
- Upstream changed the log flags
- We don't want to surprise our users
- We figured they'd check in the log that changed
- This warns the user if they're using deprecated flags so they can understand why their log output might be different and fix it :smile: 

Downstream cherry-pick of https://github.com/kedacore/keda/pull/7312 