### PR TITLE
AUTOSCALE-595: add openshift gcp test config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,10 +136,12 @@ e2e-test-openshift-setup: ## Setup the tests for OpenShift
 	@echo "--- Performing Setup ---"
 	cd tests; go test -v -timeout 15m -tags e2e ./utils/setup_test.go
 
+E2E_TEST_CONFIG ?= openshift-e2e.yaml
+
 .PHONY: e2e-test-openshift
 e2e-test-openshift: ## Run tests for OpenShift
 	@echo "--- Running OpenShift KEDA Tests ---"
-	E2E_TEST_CONFIG=openshift-e2e.yaml go run -tags e2e ./tests/run-all.go
+	E2E_TEST_CONFIG=$(E2E_TEST_CONFIG) go run -tags e2e ./tests/run-all.go
 
 .PHONY: e2e-test-openshift-clean
 e2e-test-openshift-clean: ## Cleanup the test environment for OpenShift

--- a/controllers/keda/scaledjob_controller.go
+++ b/controllers/keda/scaledjob_controller.go
@@ -106,9 +106,7 @@ func (r *ScaledJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	err := r.Get(ctx, req.NamespacedName, scaledJob)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
+			r.updatePromMetricsOnDelete(req.String())
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -123,12 +121,13 @@ func (r *ScaledJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if scaledJob.GetDeletionTimestamp() != nil {
 		return ctrl.Result{}, r.finalizeScaledJob(ctx, reqLogger, scaledJob, req.String())
 	}
-	r.updatePromMetrics(scaledJob, req.String())
 
 	// ensure finalizer is set on this CR
 	if err := r.ensureFinalizer(ctx, reqLogger, scaledJob); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	r.updatePromMetrics(scaledJob, req.String())
 
 	// ensure Status Conditions are initialized
 	if !scaledJob.Status.Conditions.AreInitialized() {

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -158,9 +158,7 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	err := r.Client.Get(ctx, req.NamespacedName, scaledObject)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
+			r.updatePromMetricsOnDelete(req.String())
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -175,12 +173,13 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if scaledObject.GetDeletionTimestamp() != nil {
 		return ctrl.Result{}, r.finalizeScaledObject(ctx, reqLogger, scaledObject, req.String())
 	}
-	r.updatePromMetrics(scaledObject, req.String())
 
 	// ensure finalizer is set on this CR
 	if err := r.ensureFinalizer(ctx, reqLogger, scaledObject); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	r.updatePromMetrics(scaledObject, req.String())
 
 	// ensure Status Conditions are initialized
 	if !scaledObject.Status.Conditions.AreInitialized() {

--- a/openshift-e2e-gcp.yaml
+++ b/openshift-e2e-gcp.yaml
@@ -1,0 +1,26 @@
+keda:
+  skipSetup: true
+  skipCleanup: true
+testCategories:
+  internals:
+    mode: exclude
+    tests:
+      - eventemitter/azureeventgridtopic
+      - global_custom_ca
+  scalers:
+    mode: include
+    tests:
+      - cpu
+      - cron
+      - kafka
+      - kubernetes_workload
+      - memory
+      - prometheus
+  secret-providers:
+    mode: include
+    tests:
+      - gcp_secret_manager_workload_identity
+  sequential:
+    mode: exclude
+    tests:
+      - datadog_dca

--- a/tests/internals/events/events_test.go
+++ b/tests/internals/events/events_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/kubernetes"
@@ -324,12 +325,15 @@ func getTemplateData() (templateData, []Template) {
 	}, []Template{}
 }
 
-func checkingEvent(t *testing.T, namespace string, scaledObject string, index int, eventReason string, message string) {
-	result, err := ExecuteCommand(fmt.Sprintf("kubectl get events -n %s --field-selector involvedObject.name=%s --sort-by=.metadata.creationTimestamp -o jsonpath=\"{.items[%d].reason}:{.items[%d].message}\"", namespace, scaledObject, index, index))
-
-	assert.NoError(t, err)
-	lastEventMessage := strings.Trim(string(result), "\"")
-	assert.Contains(t, lastEventMessage, eventReason+":"+message)
+func checkingEvent(t *testing.T, namespace string, scaledObject string, index int, eventReason string, msg string) {
+	assert.Eventually(t, func() bool {
+		result, err := ExecuteCommand(fmt.Sprintf("kubectl get events -n %s --field-selector involvedObject.name=%s --sort-by=.metadata.creationTimestamp -o jsonpath=\"{.items[%d].reason}:{.items[%d].message}\"", namespace, scaledObject, index, index))
+		if err != nil {
+			return false
+		}
+		lastEventMessage := strings.Trim(string(result), "\"")
+		return strings.Contains(lastEventMessage, eventReason+":"+msg)
+	}, 60*time.Second, 2*time.Second, "expected event %s:%s for %s/%s[%d]", eventReason, msg, namespace, scaledObject, index)
 }
 
 func testNormalEvent(t *testing.T, kc *kubernetes.Clientset, data templateData) {

--- a/tests/internals/min_replica_sj/min_replica_sj_test.go
+++ b/tests/internals/min_replica_sj/min_replica_sj_test.go
@@ -142,6 +142,9 @@ func TestMinReplicaCount(t *testing.T) {
 
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, scalerName, testNamespace, 1, 60, 1),
+		"external scaler should be ready before proceeding")
+
 	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, minReplicaCount, iterationCount, 1),
 		"job count should be %d after %d iterations", minReplicaCount, iterationCount)
 
@@ -161,6 +164,8 @@ func testMinReplicaCountWithMetricValue(t *testing.T, kc *kubernetes.Clientset, 
 
 	KubectlApplyWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
 	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	assert.True(t, WaitForJobSuccess(t, kc, "update-metric-value", testNamespace, 30, 2),
+		"update-metric-value job should complete")
 
 	expectedTarget := data.MinReplicaCount + data.MetricValue
 	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, expectedTarget, iterationCount, 1),
@@ -177,6 +182,8 @@ func testMinReplicaCountGreaterMaxReplicaCountScalesOnlyToMaxReplicaCount(t *tes
 
 	KubectlApplyWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
 	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	assert.True(t, WaitForJobSuccess(t, kc, "update-metric-value", testNamespace, 30, 2),
+		"update-metric-value job should complete")
 
 	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, data.MaxReplicaCount, iterationCount, 1),
 		"job count should be %d after %d iterations", data.MaxReplicaCount, iterationCount)
@@ -192,6 +199,8 @@ func testMinReplicaCountWithMetricValueGreaterMaxReplicaCountScalesOnlyToMaxRepl
 
 	KubectlApplyWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
 	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	assert.True(t, WaitForJobSuccess(t, kc, "update-metric-value", testNamespace, 30, 2),
+		"update-metric-value job should complete")
 
 	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, data.MaxReplicaCount, iterationCount, 1),
 		"job count should be %d after %d iterations", data.MaxReplicaCount, iterationCount)

--- a/tests/run-all.go
+++ b/tests/run-all.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	concurrentTests        = 25
+	concurrentTests        = 10 // TODO(maxcao13): openshift is too heavy for 25 concurrent tests, especially when tests do not account for kube-api race conditions
 	regularTestsTimeout    = "20m"
 	regularTestsRetries    = 3
 	sequentialTestsTimeout = "20m"

--- a/tests/sequential/disruption/disruption_test.go
+++ b/tests/sequential/disruption/disruption_test.go
@@ -151,14 +151,16 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to maxReplicaCount - 2 replicas
 	replicas := maxReplicaCount - 2
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 1),
+		"monitored deployment should reach %d ready replicas before disruption", replicas)
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	var wg sync.WaitGroup
 	wg.Add(scaledObjectCount)
 	for i := 0; i < scaledObjectCount; i++ {
 		go func(index int) {
-			assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, fmt.Sprintf(sutDeploymentName, index), testNamespace, replicas, 60, 3),
-				fmt.Sprintf("replica count should be %d after 3 minutes", replicas))
+			assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, fmt.Sprintf(sutDeploymentName, index), testNamespace, replicas, 100, 3),
+				fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 			wg.Done()
 		}(i)
 	}
@@ -167,13 +169,15 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to maxReplicaCount - 1 replicas
 	replicas = maxReplicaCount - 1
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 1),
+		"monitored deployment should reach %d ready replicas before disruption", replicas)
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	wg.Add(scaledObjectCount)
 	for i := 0; i < scaledObjectCount; i++ {
 		go func(index int) {
-			assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, fmt.Sprintf(sutDeploymentName, index), testNamespace, replicas, 60, 3),
-				fmt.Sprintf("replica count should be %d after 3 minutes", replicas))
+			assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, fmt.Sprintf(sutDeploymentName, index), testNamespace, replicas, 100, 3),
+				fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 			wg.Done()
 		}(i)
 	}
@@ -182,13 +186,15 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to maxReplicaCount replicas
 	replicas = maxReplicaCount
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 1),
+		"monitored deployment should reach %d ready replicas before disruption", replicas)
 	saveLogs(t, kc, msLogName, msLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, msLabelSelector, kedaNamespace)
 	wg.Add(scaledObjectCount)
 	for i := 0; i < scaledObjectCount; i++ {
 		go func(index int) {
-			assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, fmt.Sprintf(sutDeploymentName, index), testNamespace, replicas, 60, 3),
-				fmt.Sprintf("replica count should be %d after 3 minutes", replicas))
+			assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, fmt.Sprintf(sutDeploymentName, index), testNamespace, replicas, 100, 3),
+				fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 			wg.Done()
 		}(i)
 	}
@@ -199,6 +205,8 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to minReplicaCount + 1 replicas
 	replicas := minReplicaCount + 1
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 1),
+		"monitored deployment should reach %d ready replicas before disruption", replicas)
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	saveLogs(t, kc, msLogName, msLabelSelector, kedaNamespace)
@@ -207,8 +215,8 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	wg.Add(scaledObjectCount)
 	for i := 0; i < scaledObjectCount; i++ {
 		go func(index int) {
-			assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, fmt.Sprintf(sutDeploymentName, index), testNamespace, replicas, 60, 3),
-				fmt.Sprintf("replica count should be %d after 3 minutes", replicas))
+			assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, fmt.Sprintf(sutDeploymentName, index), testNamespace, replicas, 100, 3),
+				fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 			wg.Done()
 		}(i)
 	}
@@ -222,8 +230,8 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	wg.Add(scaledObjectCount)
 	for i := 0; i < scaledObjectCount; i++ {
 		go func(index int) {
-			assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, fmt.Sprintf(sutDeploymentName, index), testNamespace, replicas, 60, 3),
-				fmt.Sprintf("replica count should be %d after 3 minutes", replicas))
+			assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, fmt.Sprintf(sutDeploymentName, index), testNamespace, replicas, 100, 3),
+				fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 			wg.Done()
 		}(i)
 	}


### PR DESCRIPTION
Adds openshift-e2e-gcp.yaml.
Also allows Makefile openshift test target to arbitrarily target any config file. Defaults to openshift-e2e.yaml which is supposed to be for aws.
