### PR TITLE
AUTOSCALE-966: Switch to OCP base images

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,7 +1,7 @@
  # This dockerfile is intended to build something approximating the upstream test
  # image, but for use in OpenShift CI. Upstream keda bumps the keda-tools image version
  # when they feel like it, so we might just need to pay attention when we do releases.
- FROM ghcr.io/kedacore/keda-tools:1.24.7
+ FROM ghcr.io/kedacore/keda-tools:1.26.2
  COPY . /src
  RUN chmod 777 -R /src
  WORKDIR /src

--- a/openshift/Containerfile.adapter.rhel
+++ b/openshift/Containerfile.adapter.rhel
@@ -1,0 +1,17 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
+
+ARG BUILD_VERSION=main
+ARG GIT_COMMIT=HEAD
+
+WORKDIR /workspace
+COPY . .
+
+RUN CGO_ENABLED=0 go build -mod=vendor \
+    -ldflags "-X=github.com/kedacore/keda/v2/version.GitCommit=${GIT_COMMIT} -X=github.com/kedacore/keda/v2/version.Version=${BUILD_VERSION}" \
+    -o bin/keda-adapter cmd/adapter/main.go
+
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+COPY --from=builder /workspace/bin/keda-adapter /usr/bin/
+# Symlink for backwards compatibility with CMA operator manifests that reference the upstream path.
+RUN ln -s /usr/bin/keda-adapter /keda-adapter
+ENTRYPOINT ["/usr/bin/keda-adapter", "--secure-port=6443", "--zap-log-level=info", "--zap-encoder=console"]

--- a/openshift/Containerfile.rhel
+++ b/openshift/Containerfile.rhel
@@ -1,0 +1,17 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
+
+ARG BUILD_VERSION=main
+ARG GIT_COMMIT=HEAD
+
+WORKDIR /workspace
+COPY . .
+
+RUN CGO_ENABLED=0 go build -mod=vendor \
+    -ldflags "-X=github.com/kedacore/keda/v2/version.GitCommit=${GIT_COMMIT} -X=github.com/kedacore/keda/v2/version.Version=${BUILD_VERSION}" \
+    -o bin/keda cmd/operator/main.go
+
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+COPY --from=builder /workspace/bin/keda /usr/bin/
+# Symlink for backwards compatibility with CMA operator manifests that reference the upstream path.
+RUN ln -s /usr/bin/keda /keda
+ENTRYPOINT ["/usr/bin/keda", "--zap-log-level=info", "--zap-encoder=console"]

--- a/openshift/Containerfile.webhooks.rhel
+++ b/openshift/Containerfile.webhooks.rhel
@@ -1,0 +1,17 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
+
+ARG BUILD_VERSION=main
+ARG GIT_COMMIT=HEAD
+
+WORKDIR /workspace
+COPY . .
+
+RUN CGO_ENABLED=0 go build -mod=vendor \
+    -ldflags "-X=github.com/kedacore/keda/v2/version.GitCommit=${GIT_COMMIT} -X=github.com/kedacore/keda/v2/version.Version=${BUILD_VERSION}" \
+    -o bin/keda-admission-webhooks cmd/webhooks/main.go
+
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+COPY --from=builder /workspace/bin/keda-admission-webhooks /usr/bin/
+# Symlink for backwards compatibility with CMA operator manifests that reference the upstream path.
+RUN ln -s /usr/bin/keda-admission-webhooks /keda-admission-webhooks
+ENTRYPOINT ["/usr/bin/keda-admission-webhooks", "--zap-log-level=info", "--zap-encoder=console"]


### PR DESCRIPTION
Move OCP-specific Containerfiles to `openshift/` directory following the standard structure used by other OCP operator repos (e.g. karpenter-operator).

**Builder:** `ghcr.io/kedacore/keda-tools` -> `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0`
**Base:** `gcr.io/distroless/static:nonroot` -> `registry.ci.openshift.org/ocp/5.0:base-rhel9`

The original upstream Dockerfiles are left untouched so rebases stay clean. CI picks up `openshift/Containerfile.rhel`, `openshift/Containerfile.adapter.rhel`, and `openshift/Containerfile.webhooks.rhel` via openshift/release.

Also bumps `.ci-operator.yaml` build root from `golang-1.25-openshift-4.22` to `golang-1.26-openshift-5.0`.

keda-tools is ubuntu:22.04 with Go, Azure CLI, kubectl, operator-sdk, protoc, and more baked in. The build Containerfiles only ever call `go build` — none of that extra tooling gets used.

The upstream Dockerfiles also carried several patterns that don't apply in OCP:

- Drop `--platform`/`$BUILDPLATFORM`/`TARGETOS`/`TARGETARCH` — no cross compilation in OCP images.
- Use `go build -mod=vendor` directly instead of make targets. `make manager/adapter/webhooks` pulls in a generate step requiring controller-gen, mockgen and protoc, none of which ship in the OCP builder. The generated code is already committed.
- Drop `GOCACHE --mount=type=cache` — no shared build cache between CI jobs.
- Drop `USER 65532:65532` — not needed in RHEL base images.
- Install binaries to `/usr/bin/` matching other OCP operators.
- Add symlinks from upstream root paths (`/keda`, `/keda-adapter`, `/keda-admission-webhooks`) to `/usr/bin/` for compatibility with CMA operator manifests that reference the upstream binary locations.

`Dockerfile.tests` stays on keda-tools since it actually needs helm, kubectl and go for e2e. Bumped its tag from 1.24.7 to 1.26.2 to match the Go version in the production images.