### PR TITLE
NO-JIRA: Fix flaky E2E tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Check updated status for Fallback condition instead of ScaledObject ([#7488](https://github.com/kedacore/keda/issues/7488))
+- **General**: Fail fast in `GetMetrics` when the gRPC connection is in Shutdown state instead of waiting for context timeout ([#7251](https://github.com/kedacore/keda/issues/7251))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -27,6 +27,7 @@ import (
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/keepalive"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 
@@ -69,6 +70,14 @@ func NewGrpcClient(ctx context.Context, url, certDir, authority, confOptions str
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDefaultServiceConfig(confOptions),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                30 * time.Second, // Send keepalive pings every 30s
+			Timeout:             10 * time.Second, // Wait 10s for ping ack before considering connection dead
+			PermitWithoutStream: true,             // Send pings even without active RPCs
+		}),
+		grpc.WithConnectParams(grpc.ConnectParams{
+			MinConnectTimeout: 5 * time.Second,
+		}),
 	}
 
 	opts = append(
@@ -97,6 +106,12 @@ func NewGrpcClient(ctx context.Context, url, certDir, authority, confOptions str
 }
 
 func (c *GrpcClient) GetMetrics(ctx context.Context, scaledObjectName, scaledObjectNamespace, metricName string) (*external_metrics.ExternalMetricValueList, error) {
+	// Fail fast if the gRPC connection has been shut down, rather than
+	// waiting until the context timeout expires.
+	if state := c.connection.GetState(); state == connectivity.Shutdown {
+		return nil, fmt.Errorf("gRPC connection is shut down")
+	}
+
 	v1beta1ExtMetrics, err := c.client.GetMetrics(ctx, &api.ScaledObjectRef{Name: scaledObjectName, Namespace: scaledObjectNamespace, MetricName: metricName})
 	if err != nil {
 		return nil, err
@@ -213,27 +228,35 @@ func (c *GrpcClient) GetRawMetricsStream(ctx context.Context, subscriber string)
 	return metricsChan, doneChan, nil
 }
 
-// WaitForConnectionReady waits for gRPC connection to be ready
-// returns true if the connection was successful, false if we hit a timeout from context
+// WaitForConnectionReady waits for the gRPC connection to reach the Ready state.
+// It uses WaitForStateChange to efficiently wait for state transitions rather than
+// busy-polling, which allows the gRPC transport to properly handle reconnection
+// with its built-in backoff logic.
+// Returns true if the connection is ready, false if the context is cancelled.
 func (c *GrpcClient) WaitForConnectionReady(ctx context.Context, logger logr.Logger) bool {
-	currentState := c.connection.GetState()
-	if currentState != connectivity.Ready {
-		logger.Info("Waiting for establishing a gRPC connection to KEDA Metrics Server")
-		for {
-			select {
-			case <-ctx.Done():
-				return false
-			default:
-				c.connection.Connect()
-				time.Sleep(500 * time.Millisecond)
-				currentState := c.connection.GetState()
-				if currentState == connectivity.Ready {
-					return true
-				}
-			}
+	for {
+		currentState := c.connection.GetState()
+		if currentState == connectivity.Ready {
+			return true
+		}
+
+		logger.Info("Waiting for establishing a gRPC connection to KEDA Metrics Server",
+			"currentState", currentState.String())
+
+		// Trigger a connection attempt if the connection is idle
+		if currentState == connectivity.Idle {
+			c.connection.Connect()
+		}
+
+		// Wait for the state to change or context to be cancelled.
+		// WaitForStateChange blocks until the connection transitions away from
+		// the given state, allowing gRPC's internal reconnection backoff to
+		// work properly instead of interfering with it via busy-polling.
+		if !c.connection.WaitForStateChange(ctx, currentState) {
+			// Context was cancelled
+			return false
 		}
 	}
-	return true
 }
 
 // GetServerURL returns url of the gRPC server this client is connected to

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -1200,16 +1200,35 @@ func generateCA(t *testing.T) {
 	}
 }
 
-// CheckKubectlGetResult runs `kubectl get` with parameters and compares output with expected value
+// The fields this reads are written by the operator as it reconciles the resource that references
+// the authentication, so they lag the apply or delete that triggered the change. A minute is many
+// times a reconcile and is only reached when the operator has genuinely stopped updating them.
+const kubectlGetResultTimeout = time.Minute
+
+// CheckKubectlGetResult runs `kubectl get` with parameters and waits for the output to match the
+// expected value.
 func CheckKubectlGetResult(t *testing.T, kind string, name string, namespace string, otherparameter string, expected string) {
-	time.Sleep(1 * time.Second) // wait a second for recource deployment finished
 	kctlGetCmd := fmt.Sprintf(`kubectl get %s/%s -n %s %s"`, kind, name, namespace, otherparameter)
 	t.Log("Running kubectl cmd:", kctlGetCmd)
-	output, err := ExecuteCommand(kctlGetCmd)
-	assert.NoErrorf(t, err, "cannot get rollout info - %s", err)
 
-	unqoutedOutput := strings.ReplaceAll(string(output), "\"", "")
-	assert.Equal(t, expected, unqoutedOutput)
+	ctx, cancel := context.WithTimeout(context.Background(), kubectlGetResultTimeout)
+	defer cancel()
+
+	lastRead := "<nothing read>"
+	err := KedaEventually(ctx, func(_ context.Context) (bool, error) {
+		output, cmdErr := ExecuteCommand(kctlGetCmd)
+		if cmdErr != nil {
+			// Retried rather than reported, so that a command that fails while the resource is
+			// still being created does not end the wait.
+			lastRead = fmt.Sprintf("<command failed: %s>", cmdErr)
+			return false, nil
+		}
+
+		lastRead = strings.ReplaceAll(string(output), "\"", "")
+		return lastRead == expected, nil
+	}, IntervalShort)
+
+	assert.NoErrorf(t, err, "%s/%s %s: expected %q, last read %q", kind, name, otherparameter, expected, lastRead)
 }
 
 // KedaEventually checks if the provided conditionFunc eventually returns true

--- a/tests/internals/scaled_job_validation/scaled_job_validation_test.go
+++ b/tests/internals/scaled_job_validation/scaled_job_validation_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/kedacore/keda/v2/tests/helper"
 )
@@ -126,7 +127,7 @@ func testTriggersWithEmptyArray(t *testing.T, data templateData) {
 	t.Log("--- triggers with empty array ---")
 
 	err := KubectlApplyWithErrors(t, data, "emptyTriggersSjTemplate", emptyTriggersSjTemplate)
-	assert.Errorf(t, err, "can deploy the scaledJob - %s", err)
+	require.Errorf(t, err, "can deploy the scaledJob - %s", err)
 	assert.Contains(t, err.Error(), "spec.triggers in body should have at least 1 items")
 }
 

--- a/tests/internals/scaled_object_validation/scaled_object_validation_test.go
+++ b/tests/internals/scaled_object_validation/scaled_object_validation_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/kedacore/keda/v2/tests/helper"
 )
@@ -262,11 +263,11 @@ func testScaledWorkloadByOtherScaledObject(t *testing.T, data templateData) {
 
 	data.ScaledObjectName = scaledObject1Name
 	err := KubectlApplyWithErrors(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	assert.NoErrorf(t, err, "cannot deploy the scaledObject - %s", err)
+	require.NoErrorf(t, err, "cannot deploy the scaledObject - %s", err)
 
 	data.ScaledObjectName = scaledObject2Name
 	err = KubectlApplyWithErrors(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the workload '%s' of type 'apps/v1.Deployment' is already managed by the ScaledObject '%s", deploymentName, scaledObject1Name))
 
 	data.ScaledObjectName = scaledObject1Name
@@ -280,12 +281,12 @@ func testManagedHpaByOtherScaledObject(t *testing.T, data templateData) {
 
 	data.ScaledObjectName = scaledObject1Name
 	err := KubectlApplyWithErrors(t, data, "scaledObjectTemplate", customHpaScaledObjectTemplate)
-	assert.NoErrorf(t, err, "cannot deploy the scaledObject - %s", err)
+	require.NoErrorf(t, err, "cannot deploy the scaledObject - %s", err)
 
 	data.ScaledObjectName = scaledObject2Name
 	data.DeploymentName = fmt.Sprintf("%s-other-deployment", testName)
 	err = KubectlApplyWithErrors(t, data, "scaledObjectTemplate", customHpaScaledObjectTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the HPA '%s' is already managed by the ScaledObject '%s", hpaName, scaledObject1Name))
 
 	data.ScaledObjectName = scaledObject1Name
@@ -297,11 +298,11 @@ func testScaledWorkloadByOtherHpa(t *testing.T, data templateData) {
 
 	data.HpaName = hpaName
 	err := KubectlApplyWithErrors(t, data, "hpaTemplate", hpaTemplate)
-	assert.NoErrorf(t, err, "cannot deploy the hpa - %s", err)
+	require.NoErrorf(t, err, "cannot deploy the hpa - %s", err)
 
 	data.ScaledObjectName = scaledObject1Name
 	err = KubectlApplyWithErrors(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the workload '%s' of type 'apps/v1.Deployment' is already managed by the hpa '%s", deploymentName, hpaName))
 
 	KubectlDeleteWithTemplate(t, data, "hpaTemplate", hpaTemplate)
@@ -327,7 +328,7 @@ func testMissingCPU(t *testing.T, data templateData) {
 
 	data.ScaledObjectName = scaledObject1Name
 	err := KubectlApplyWithErrors(t, data, "scaledObjectTemplate", cpuScaledObjectTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the scaledobject has a cpu trigger but the container %s doesn't have the cpu request defined", deploymentName))
 }
 
@@ -336,7 +337,7 @@ func testMissingMemory(t *testing.T, data templateData) {
 
 	data.ScaledObjectName = scaledObject1Name
 	err := KubectlApplyWithErrors(t, data, "scaledObjectTemplate", memoryScaledObjectTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the scaledobject has a memory trigger but the container %s doesn't have the memory request defined", deploymentName))
 }
 
@@ -404,7 +405,7 @@ func testTriggersWithEmptyArray(t *testing.T, data templateData) {
 	t.Log("--- triggers with empty array ---")
 
 	err := KubectlApplyWithErrors(t, data, "emptyTriggersTemplate", emptyTriggersTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), "spec.triggers in body should have at least 1 items")
 }
 

--- a/tests/scalers/cron/cron_test.go
+++ b/tests/scalers/cron/cron_test.go
@@ -24,9 +24,8 @@ var (
 	deploymentName   = fmt.Sprintf("%s-deployment", testName)
 	scaledObjectName = fmt.Sprintf("%s-so", testName)
 
-	now   = time.Now().Local()
-	start = (now.Minute() + 1) % 60
-	end   = (start + 1) % 60
+	start int
+	end   int
 )
 
 type templateData struct {
@@ -92,6 +91,12 @@ spec:
 func TestScaler(t *testing.T) {
 	// setup
 	t.Log("--- setting up ---")
+
+	// Compute the cron schedule just before creating resources so the
+	// trigger window does not expire during setup.
+	now := time.Now().Local()
+	start = (now.Minute() + 1) % 60
+	end = (start + 1) % 60
 
 	// Create kubernetes resources
 	kc := GetKubernetesClient(t)

--- a/tests/sequential/broken_scaledobject_tolerancy/broken_scaledobject_tolerancy_test.go
+++ b/tests/sequential/broken_scaledobject_tolerancy/broken_scaledobject_tolerancy_test.go
@@ -161,26 +161,26 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to 2 replicas
 	replicas := 2
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 10, 6),
-		fmt.Sprintf("replica count should be %d after 1 minute", replicas))
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 60, 5),
+		fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 
 	// scale monitored deployment to 4 replicas
 	replicas = 4
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 10, 6),
-		fmt.Sprintf("replica count should be %d after 1 minute", replicas))
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 60, 5),
+		fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to 2 replicas
 	replicas := 2
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 10, 6),
-		fmt.Sprintf("replica count should be %d after 1 minute", replicas))
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 60, 5),
+		fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 
 	// scale monitored deployment to 0 replicas
 	replicas = 0
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 10, 6),
-		fmt.Sprintf("replica count should be %d after 1 minute", replicas))
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 60, 5),
+		fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 }

--- a/tests/sequential/disruption/disruption_test.go
+++ b/tests/sequential/disruption/disruption_test.go
@@ -151,6 +151,8 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to maxReplicaCount - 2 replicas
 	replicas := maxReplicaCount - 2
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 5),
+		"monitored deployment should be ready before operator disruption")
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	var wg sync.WaitGroup
@@ -167,6 +169,8 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to maxReplicaCount - 1 replicas
 	replicas = maxReplicaCount - 1
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 5),
+		"monitored deployment should be ready before operator disruption")
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	wg.Add(scaledObjectCount)
@@ -182,6 +186,8 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to maxReplicaCount replicas
 	replicas = maxReplicaCount
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 5),
+		"monitored deployment should be ready before metrics-server disruption")
 	saveLogs(t, kc, msLogName, msLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, msLabelSelector, kedaNamespace)
 	wg.Add(scaledObjectCount)
@@ -199,6 +205,8 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to minReplicaCount + 1 replicas
 	replicas := minReplicaCount + 1
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 5),
+		"monitored deployment should be ready before operator/metrics-server disruption")
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	saveLogs(t, kc, msLogName, msLabelSelector, kedaNamespace)
@@ -217,6 +225,8 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to minReplicaCount replicas
 	replicas = minReplicaCount
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 5),
+		"monitored deployment should be ready before operator disruption")
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	wg.Add(scaledObjectCount)


### PR DESCRIPTION
Fixes flaky e2e tests on OpenShift CI, mostly with a combination of actually waiting for resources to reach their expected state and a few increased timeouts.

All test-fix commits here are upstreamed and merged: two were already fixed independently in upstream and for the new findings I did open https://github.com/kedacore/keda/pull/8063 .

### Procedure
I fixed these issues as follows:
1. Run CI and collect logs etc.
2. Identify the cause of failing tests together with the probability that this is actually an issue
3. Push the fixes and observe CI
	- infra related failures (e.g. GCP clusters not starting) -> retry and ignore
	- other failures: investigate and fix again and start at 1. again
	- success: run at least 2x without flakes/failures
4. Remove low confidence fixes and retest to see if CI still succeeds
	- e.g. the GRPC issue already fixed in upstream triggered a few low confidence fixes (like increased timeouts) until I discovered the actual root cause.

### Commits

**`UPSTREAM: 7463: fix(metricsservice): improve gRPC connection resilience...`**

Backport of [kedacore/keda#7463](https://github.com/kedacore/keda/pull/7463): Fixes a stale GRPC connection between `keda-metrics-apiserver` and `keda-operator` after an operator restart, which caused most `disruption_test` failures on OVN-Kubernetes.

**`UPSTREAM: 8023: test: wait for the status CheckKubectlGetResult reads (#8023)`**

Cherry-pick of [kedacore/keda#8023](https://github.com/kedacore/keda/pull/8023), which was merged upstream independently while I was working on this. `CheckKubectlGetResult` slept 1s then checked once; upstream's fix polls up to 60s instead.

**`UPSTREAM: 8063: test: fix e2e races and timeouts in cron, disruption and validation tests`**

Cherry-pick of [kedacore/keda#8063](https://github.com/kedacore/keda/pull/8063), which I opened upstream with the remaining fixes from this PR:

1. **`cron_test.go`**: The cron trigger window was computed at package init before any test setup ran. On slow OCP setup (which took up to 150s), the window had already closed by the time the test checked it.
	- Moved the computation into `TestScaler` right before resource creation.
2. **`disruption_test.go`**: the test killed the KEDA operator/metrics-server before the monitored deployment's pods were confirmed running (`KubernetesScaleDeployment` only sets `spec.replicas`, doesn't wait), so the trigger signal it should react to on recovery didn't reflect the intended value yet.
	- Added a wait for the monitored deployment to be ready before each disruption.
3. **`scaled_object_validation_test.go` / `scaled_job_validation_test.go`**: Not really a fix for a flaky test but rather a bug fix. A transient API error during setup could leave `err=nil` where the test expected an error. The next line unconditionally called `err.Error()`, panicking the whole test.
	- Replaced `assert` with `require` at the 10 affected call sites so a failure stops that test cleanly instead of crashing the run.
4. **`broken_scaledobject_tolerancy_test.go`**: Increased the timeout similar to other call sites to handle the slower OCP environment.



### Verification

Validated over 8 consecutive CI run-pairs (AWS + GCP) across the original 3 commits, all 43/43 e2e tests passing on both platforms.