### PR TITLE
AUTOSCALE-971: Use server-side apply for Argo Rollouts

### DIFF
--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -70,7 +70,7 @@ func TestSetupArgoRollouts(t *testing.T) {
 	}
 	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, ArgoRolloutsNamespace)
-	cmdWithNamespace := fmt.Sprintf("kubectl apply -n %s -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml",
+	cmdWithNamespace := fmt.Sprintf("kubectl apply --server-side -n %s -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml",
 		ArgoRolloutsNamespace)
 	_, err := ExecuteCommand(cmdWithNamespace)
 


### PR DESCRIPTION
The Argo Rollouts CRDs now exceed the annotation size limit used by client-side apply. Use server-side apply so the e2e setup does not store the complete CRD manifests in the last-applied-configuration annotation.

This follows the Argo Rollouts fix documented in https://github.com/argoproj/argo-rollouts/pull/4687.

Related PR: https://github.com/openshift/custom-metrics-autoscaler-operator/pull/100#issuecomment-5443855944

We can of course wait for the merge of the upstream PR which is why I'm adding `WIP: ` to the PR title: https://github.com/kedacore/keda/pull/8094
 
fyi @joelsmith 
